### PR TITLE
RabbitMQ Username via URL

### DIFF
--- a/mqclient/broker_clients/rabbitmq.py
+++ b/mqclient/broker_clients/rabbitmq.py
@@ -27,17 +27,17 @@ StrDict = Dict[str, Any]
 
 LOGGER = logging.getLogger("mqclient.rabbitmq")
 
+# url parsing constants
+HUMAN_PATTERN = "[abc://][USER[:PASS]@]HOST[:PORT][/VIRTUAL_HOST]"
+REGEX_PATTERN = r"([^:/]+://)?(?P<host>[^:/]*)(:(?P<port>\d+))?(/(?P<virtual_host>.+))?"
+REGEX_PATTERN_COMPILED = re.compile(REGEX_PATTERN)
+
 
 def _parse_url(url: str) -> StrDict:
-    human_pattern = "[abc://][USER[:PASS]@]HOST[:PORT][/VIRTUAL_HOST]"
-    regex_pattern = (
-        r"([^:/]+://)?(?P<host>[^:/]*)(:(?P<port>\d+))?(/(?P<virtual_host>.+))?"
-    )
-
     try:
-        parts = re.match(regex_pattern, url).groupdict()  # type: ignore[union-attr]
+        parts = REGEX_PATTERN_COMPILED.match(url).groupdict()  # type: ignore[union-attr]
     except TypeError as e:
-        raise RuntimeError(f"Invalid address: {url} (format: {human_pattern})") from e
+        raise RuntimeError(f"Invalid address: {url} (format: {HUMAN_PATTERN})") from e
 
     # for putting into ConnectionParameters filter Nones (will rely on defaults)
     parts = {k: v for k, v in parts.items() if v is not None}  # host=..., etc.

--- a/mqclient/broker_clients/rabbitmq.py
+++ b/mqclient/broker_clients/rabbitmq.py
@@ -41,6 +41,9 @@ def _parse_url(url: str) -> StrDict:
 
     # for putting into ConnectionParameters filter Nones (will rely on defaults)
     parts = {k: v for k, v in parts.items() if v is not None}  # host=..., etc.
+
+    if "port" in parts:
+        parts["port"] = int(parts["port"])
     return parts
 
 

--- a/mqclient/broker_clients/rabbitmq.py
+++ b/mqclient/broker_clients/rabbitmq.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import re
 import time
 import urllib
 from functools import partial
@@ -65,7 +64,7 @@ class RabbitMQ(RawQueue):
         LOGGER.info(f"Requested MQClient for queue '{queue}' @ {address}")
 
         # set up connection parameters
-
+        cp_args = _parse_url(address)
         if auth_token:
             cp_args["credentials"] = pika.credentials.PlainCredentials("", auth_token)
         if os.getenv("RABBITMQ_HEARTBEAT"):

--- a/mqclient/broker_clients/rabbitmq.py
+++ b/mqclient/broker_clients/rabbitmq.py
@@ -67,22 +67,7 @@ class RabbitMQ(RawQueue):
         # set up connection parameters
         cp_args = _parse_url(address)
         if auth_token:
-            cp_args["password"] = auth_token
-
-        username, password = cp_args.pop("hostname"), cp_args.pop("password")
-        # Case 1: no username/password
-        if username and password:
-            cp_args["credentials"] = pika.credentials.PlainCredentials(
-                username, password
-            )
-        elif (not username) and password:  # ex: keycloak
-            cp_args["credentials"] = pika.credentials.PlainCredentials("", password)
-        elif username and (not password):
-            raise RuntimeError("username given but no password or token")
-        else:  # not username and not password
-            pass
-
-            # cp_args["credentials"] = pika.credentials.PlainCredentials("", auth_token)
+            cp_args["credentials"] = pika.credentials.PlainCredentials("", auth_token)
         if os.getenv("RABBITMQ_HEARTBEAT"):
             cp_args["heartbeat"] = int(os.getenv("RABBITMQ_HEARTBEAT"))  # type: ignore[arg-type]
         self.parameters = pika.connection.ConnectionParameters(**cp_args)

--- a/mqclient/broker_clients/rabbitmq.py
+++ b/mqclient/broker_clients/rabbitmq.py
@@ -42,9 +42,10 @@ def _parse_url(url: str) -> Tuple[StrDict, Optional[str], Optional[str]]:
         port=result.port,
         virtual_host=result.path.lstrip("/"),
     )
-
     # for putting into ConnectionParameters filter ""/None (will rely on defaults)
     parts = {k: v for k, v in parts.items() if v}  # host=..., etc.
+
+    # check validity
     if not parts or "hostname" not in parts:
         raise RuntimeError(f"Invalid address: {url} (format: {HUMAN_PATTERN})")
     parts["host"] = parts.pop("hostname")

--- a/mqclient/broker_clients/rabbitmq.py
+++ b/mqclient/broker_clients/rabbitmq.py
@@ -28,8 +28,8 @@ StrDict = Dict[str, Any]
 LOGGER = logging.getLogger("mqclient.rabbitmq")
 
 # url parsing constants
-HUMAN_PATTERN = "[abc://][USER[:PASS]@]HOST[:PORT][/VIRTUAL_HOST]"
-REGEX_PATTERN = r"([^:/]+://)?(?P<host>[^:/]*)(:(?P<port>\d+))?(/(?P<virtual_host>.+))?"
+HUMAN_PATTERN = "[SCHEME://][USER[:PASS]@]HOST[:PORT][/VIRTUAL_HOST]"
+REGEX_PATTERN = r"([^:/@]+://)?((?P<username>[^:/@]+)@)?(?P<host>[^:/]+)(:(?P<port>\d+))?(/(?P<virtual_host>.+))?"
 REGEX_PATTERN_COMPILED = re.compile(REGEX_PATTERN)
 
 

--- a/mqclient/broker_clients/rabbitmq.py
+++ b/mqclient/broker_clients/rabbitmq.py
@@ -38,7 +38,7 @@ def _parse_url(url: str) -> Tuple[StrDict, Optional[str], Optional[str]]:
 
     parts = dict(
         scheme=result.scheme,
-        hostname=result.hostname,
+        host=result.hostname,
         port=result.port,
         virtual_host=result.path.lstrip("/"),
     )
@@ -46,9 +46,8 @@ def _parse_url(url: str) -> Tuple[StrDict, Optional[str], Optional[str]]:
     parts = {k: v for k, v in parts.items() if v}  # host=..., etc.
 
     # check validity
-    if not parts or "hostname" not in parts:
+    if not parts or "host" not in parts:
         raise RuntimeError(f"Invalid address: {url} (format: {HUMAN_PATTERN})")
-    parts["host"] = parts.pop("hostname")
 
     return parts, result.username, result.password
 

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -32,13 +32,13 @@ googleapis-common-protos[grpc]==1.58.0
     #   oms-mqclient (setup.py)
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.51.1
+grpcio==1.51.3
     # via
     #   google-api-core
     #   google-cloud-pubsub
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.51.1
+grpcio-status==1.51.3
     # via
     #   google-api-core
     #   google-cloud-pubsub

--- a/requirements-gcp.txt
+++ b/requirements-gcp.txt
@@ -28,13 +28,13 @@ googleapis-common-protos[grpc]==1.58.0
     #   oms-mqclient (setup.py)
 grpc-google-iam-v1==0.12.6
     # via google-cloud-pubsub
-grpcio==1.51.1
+grpcio==1.51.3
     # via
     #   google-api-core
     #   google-cloud-pubsub
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.51.1
+grpcio-status==1.51.3
     # via
     #   google-api-core
     #   google-cloud-pubsub

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --extra=integration --output-file=requirements-integration.txt
 #
-aio-pika==9.0.2
+aio-pika==9.0.4
     # via wipac-keycloak-rest-services
-aiormq==6.7.1
+aiormq==6.7.2
     # via aio-pika
 cachetools==5.3.0
     # via
@@ -25,7 +25,7 @@ dnspython==2.3.0
     # via pymongo
 google-api-core==2.11.0
     # via google-api-python-client
-google-api-python-client==2.78.0
+google-api-python-client==2.79.0
     # via wipac-keycloak-rest-services
 google-auth==2.16.1
     # via

--- a/requirements-telemetry.txt
+++ b/requirements-telemetry.txt
@@ -18,7 +18,7 @@ googleapis-common-protos==1.56.2
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.51.1
+grpcio==1.51.3
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs

--- a/tests/unit/rabbitmq/test_rabbitmq.py
+++ b/tests/unit/rabbitmq/test_rabbitmq.py
@@ -147,7 +147,7 @@ class TestUnitRabbitMQURLParsing:
                 # special optional tokens
                 if user:  # password can only be given alongside username
                     givens["password"] = "secret"
-                    pwd = f":{givens['password']}"
+                    pwd_host = f"{givens['username']}:{givens['password']}@"
                     # fmt:off
-                    assert _parse_url(f"{skm}{user}{pwd}{host}{port}{vhost}") == givens
+                    assert _parse_url(f"{skm}{user}{pwd_host}{port}{vhost}") == givens
                     # fmt: on

--- a/tests/unit/rabbitmq/test_rabbitmq.py
+++ b/tests/unit/rabbitmq/test_rabbitmq.py
@@ -116,13 +116,6 @@ class TestUnitRabbitMQ(BrokerClientUnitTest):
 class TestUnitRabbitMQURLParsing:
     """Unit test the URL-parsing by rabbitmq."""
 
-    def test_000(self) -> None:
-        """Sanity check the constants."""
-        assert HUMAN_PATTERN == ("[SCHEME://][USER[:PASS]@]HOST[:PORT][/VIRTUAL_HOST]")
-        assert REGEX_PATTERN == (
-            r"([^:/@]+://)?((?P<username>[^:/@]+)@)?(?P<host>[^:/]+)(:(?P<port>\d+))?(/(?P<virtual_host>.+))?"
-        )
-
     def test_100(self) -> None:
         """Test normal (successful) parsing."""
         tokens = dict(port=1234, virtual_host="foo", username="hank")

--- a/tests/unit/rabbitmq/test_rabbitmq.py
+++ b/tests/unit/rabbitmq/test_rabbitmq.py
@@ -125,31 +125,32 @@ class TestUnitRabbitMQURLParsing:
 
     def test_100(self) -> None:
         """Test normal (successful) parsing."""
-        stuff = dict(port=1234, virtual_host="foo")  # , username="hank")
-        for rlength in range(len(stuff) + 1):
-            for _subset in itertools.combinations(stuff.items(), rlength):
-                subdict = dict(_subset)
+        tokens = dict(port=1234, virtual_host="foo")  # , username="hank")
+        # test with every number of combinations of `tokens`
+        for rlength in range(len(tokens) + 1):
+            for _subset in itertools.combinations(tokens.items(), rlength):
+                givens = dict(_subset)
 
                 # host is mandatory
                 host = "localhost"
-                subdict["host"] = host
+                givens["host"] = host
 
                 # optional tokens
-                if user := subdict.get("username", ""):
+                if user := givens.get("username", ""):
                     user = f"{user}@"
-                if port := subdict.get("port", ""):
+                if port := givens.get("port", ""):
                     port = f":{port}"
-                if vhost := subdict.get("virtual_host", ""):
+                if vhost := givens.get("virtual_host", ""):
                     vhost = f"/{vhost}"
 
-                assert _parse_url(f"{user}{host}{port}{vhost}") == subdict
-                assert _parse_url(f"wxyz://{user}{host}{port}{vhost}") == subdict
+                assert _parse_url(f"{user}{host}{port}{vhost}") == givens
+                assert _parse_url(f"wxyz://{user}{host}{port}{vhost}") == givens
 
                 # special optional tokens
                 if user:  # password can only be given alongside username
-                    subdict["password"] = "secret"
-                    pwd = f":{subdict['password']}"
+                    givens["password"] = "secret"
+                    pwd = f":{givens['password']}"
                     # fmt:off
-                    assert _parse_url(f"{user}{pwd}{host}{port}{vhost}") == subdict
-                    assert _parse_url(f"wxyz://{user}{pwd}{host}{port}{vhost}") == subdict
+                    assert _parse_url(f"{user}{pwd}{host}{port}{vhost}") == givens
+                    assert _parse_url(f"wxyz://{user}{pwd}{host}{port}{vhost}") == givens
                     # fmt: on

--- a/tests/unit/rabbitmq/test_rabbitmq.py
+++ b/tests/unit/rabbitmq/test_rabbitmq.py
@@ -140,7 +140,7 @@ class TestUnitRabbitMQURLParsing:
                 if vhost := givens.get("virtual_host", ""):
                     vhost = f"/{vhost}"
                 if skm := givens.get("scheme", ""):
-                    skm = f":{skm}"
+                    skm = f"{skm}://"
 
                 assert _parse_url(f"{skm}{user}{host}{port}{vhost}") == givens
 

--- a/tests/unit/rabbitmq/test_rabbitmq.py
+++ b/tests/unit/rabbitmq/test_rabbitmq.py
@@ -126,13 +126,10 @@ class TestUnitRabbitMQURLParsing:
         def _get_return_tuple(
             subdict: dict, password: Optional[str] = ""
         ) -> Tuple[dict, Optional[str], Optional[str]]:
-            cp_args = {
-                v: k for v, k in subdict.items() if k not in ["username", "password"]
-            }
             return (
-                cp_args,
-                cp_args.get("username", None),
-                cp_args.get("password", password),
+                {k: v for k, v in subdict.items() if k not in ["username", "password"]},
+                subdict.get("username", None),
+                subdict.get("password", password),
             )
 
         tokens = dict(scheme="wxyz", port=1234, virtual_host="foo", username="hank")

--- a/tests/unit/rabbitmq/test_rabbitmq.py
+++ b/tests/unit/rabbitmq/test_rabbitmq.py
@@ -118,14 +118,14 @@ class TestUnitRabbitMQURLParsing:
 
     def test_000(self) -> None:
         """Sanity check the constants."""
-        assert HUMAN_PATTERN == ("[abc://][USER[:PASS]@]HOST[:PORT][/VIRTUAL_HOST]")
+        assert HUMAN_PATTERN == ("[SCHEME://][USER[:PASS]@]HOST[:PORT][/VIRTUAL_HOST]")
         assert REGEX_PATTERN == (
-            r"([^:/]+://)?(?P<host>[^:/]*)(:(?P<port>\d+))?(/(?P<virtual_host>.+))?"
+            r"([^:/@]+://)?((?P<username>[^:/@]+)@)?(?P<host>[^:/]+)(:(?P<port>\d+))?(/(?P<virtual_host>.+))?"
         )
 
     def test_100(self) -> None:
         """Test normal (successful) parsing."""
-        tokens = dict(port=1234, virtual_host="foo")  # , username="hank")
+        tokens = dict(port=1234, virtual_host="foo", username="hank")
         # test with every number of combinations of `tokens`
         for rlength in range(len(tokens) + 1):
             for _subset in itertools.combinations(tokens.items(), rlength):
@@ -147,10 +147,10 @@ class TestUnitRabbitMQURLParsing:
                 assert _parse_url(f"wxyz://{user}{host}{port}{vhost}") == givens
 
                 # special optional tokens
-                if user:  # password can only be given alongside username
-                    givens["password"] = "secret"
-                    pwd = f":{givens['password']}"
-                    # fmt:off
-                    assert _parse_url(f"{user}{pwd}{host}{port}{vhost}") == givens
-                    assert _parse_url(f"wxyz://{user}{pwd}{host}{port}{vhost}") == givens
-                    # fmt: on
+                # if user:  # password can only be given alongside username
+                #     givens["password"] = "secret"
+                #     pwd = f":{givens['password']}"
+                #     # fmt:off
+                #     assert _parse_url(f"{user}{pwd}{host}{port}{vhost}") == givens
+                #     assert _parse_url(f"wxyz://{user}{pwd}{host}{port}{vhost}") == givens
+                #     # fmt: on

--- a/tests/unit/rabbitmq/test_rabbitmq.py
+++ b/tests/unit/rabbitmq/test_rabbitmq.py
@@ -131,7 +131,7 @@ class TestUnitRabbitMQURLParsing:
             }
             return (
                 cp_args,
-                cp_args.get("username", ""),
+                cp_args.get("username", None),
                 cp_args.get("password", password),
             )
 

--- a/tests/unit/rabbitmq/test_rabbitmq.py
+++ b/tests/unit/rabbitmq/test_rabbitmq.py
@@ -130,22 +130,26 @@ class TestUnitRabbitMQURLParsing:
             for _subset in itertools.combinations(stuff.items(), rlength):
                 subdict = dict(_subset)
 
+                # host is mandatory
+                host = "localhost"
+                subdict["host"] = host
+
+                # optional tokens
                 if user := subdict.get("username", ""):
                     user = f"{user}@"
-
                 if port := subdict.get("port", ""):
                     port = f":{port}"
-
                 if vhost := subdict.get("virtual_host", ""):
                     vhost = f"/{vhost}"
 
-                assert _parse_url(f"{user}localhost{port}{vhost}") == subdict
-                assert _parse_url(f"wxyz://{user}localhost{port}{vhost}") == subdict
+                assert _parse_url(f"{user}{host}{port}{vhost}") == subdict
+                assert _parse_url(f"wxyz://{user}{host}{port}{vhost}") == subdict
 
+                # special optional tokens
                 if user:  # password can only be given alongside username
                     subdict["password"] = "secret"
                     pwd = f":{subdict['password']}"
                     # fmt:off
-                    assert _parse_url(f"{user}{pwd}localhost{port}{vhost}") == subdict
-                    assert _parse_url(f"wxyz://{user}{pwd}localhost{port}{vhost}") == subdict
+                    assert _parse_url(f"{user}{pwd}{host}{port}{vhost}") == subdict
+                    assert _parse_url(f"wxyz://{user}{pwd}{host}{port}{vhost}") == subdict
                     # fmt: on

--- a/tests/unit/rabbitmq/test_rabbitmq.py
+++ b/tests/unit/rabbitmq/test_rabbitmq.py
@@ -147,7 +147,5 @@ class TestUnitRabbitMQURLParsing:
                 # special optional tokens
                 if user:  # password can only be given alongside username
                     givens["password"] = "secret"
-                    pwd_host = f"{givens['username']}:{givens['password']}@"
-                    # fmt:off
-                    assert _parse_url(f"{skm}{user}{pwd_host}{port}{vhost}") == givens
-                    # fmt: on
+                    user_pwd = f"{givens['username']}:{givens['password']}@"
+                    assert _parse_url(f"{skm}{user_pwd}{host}{port}{vhost}") == givens


### PR DESCRIPTION
Accept a username via the URL. Also, permit an accompanying password, though this will be overridden if `auth_token` is provided.