### PR TITLE
Inactivity Timeout (`Queue.inactivity_timeout`) [minor]

### DIFF
--- a/mqclient/broker_client_interface.py
+++ b/mqclient/broker_client_interface.py
@@ -181,6 +181,7 @@ class BrokerClient:
         name: str,
         auth_token: str,
         ack_timeout: Optional[int],
+        inactivity_timeout: Optional[int],  # not used by all broker clients
     ) -> Pub:
         """Create a publishing queue."""
         raise NotImplementedError()
@@ -192,6 +193,7 @@ class BrokerClient:
         prefetch: int,
         auth_token: str,
         ack_timeout: Optional[int],
+        inactivity_timeout: Optional[int],  # not used by all broker clients
     ) -> Sub:
         """Create a subscription queue."""
         raise NotImplementedError()

--- a/mqclient/broker_clients/apachepulsar.py
+++ b/mqclient/broker_clients/apachepulsar.py
@@ -346,6 +346,7 @@ class BrokerClient(broker_client_interface.BrokerClient):
         name: str,
         auth_token: str,
         ack_timeout: Optional[int],
+        inactivity_timeout: Optional[int],  # not used by Pulsar
     ) -> PulsarPub:
         """Create a publishing queue."""
         q = PulsarPub(  # pylint: disable=invalid-name
@@ -364,6 +365,7 @@ class BrokerClient(broker_client_interface.BrokerClient):
         prefetch: int,
         auth_token: str,
         ack_timeout: Optional[int],
+        inactivity_timeout: Optional[int],  # not used by Pulsar
     ) -> PulsarSub:
         """Create a subscription queue."""
         q = PulsarSub(  # pylint: disable=invalid-name

--- a/mqclient/broker_clients/nats.py
+++ b/mqclient/broker_clients/nats.py
@@ -351,6 +351,7 @@ class BrokerClient(broker_client_interface.BrokerClient):
         name: str,
         auth_token: str,
         ack_timeout: Optional[int],
+        inactivity_timeout: Optional[int],  # not used by NATS
     ) -> NATSPub:
         """Create a publishing queue.
 
@@ -371,6 +372,7 @@ class BrokerClient(broker_client_interface.BrokerClient):
         prefetch: int,
         auth_token: str,
         ack_timeout: Optional[int],
+        inactivity_timeout: Optional[int],  # not used by NATS
     ) -> NATSSub:
         """Create a subscription queue.
 

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -65,13 +65,16 @@ class Queue:
         self._prefetch = prefetch
         self._auth_token = auth_token
 
+        # Public Vars
 
-        # publics
-        self._ack_timeout = 0
-        self.ack_timeout = ack_timeout
-        self._timeout = 0
+        # properties
+        self._timeout = timeout
         self.timeout = timeout
+        #
+        self._ack_timeout = ack_timeout
+        self.ack_timeout = ack_timeout
 
+        # others
         self.except_errors = except_errors
 
     @staticmethod
@@ -95,15 +98,15 @@ class Queue:
         self._timeout = val
 
     @property
-    def ack_timeout(self) -> int:
+    def ack_timeout(self) -> Optional[int]:
         """Get the ack_timeout value."""
         return self._ack_timeout
 
     @ack_timeout.setter
-    def ack_timeout(self, val: int) -> None:
+    def ack_timeout(self, val: Optional[int]) -> None:
         LOGGER.debug(f"Setting ack_timeout to {val}")
-        if val < 1:
-            raise ValueError("ack_timeout must be positive")
+        if val is not None and val < 1:
+            raise ValueError("ack_timeout must be positive or None")
         self._ack_timeout = val
     async def _create_pub_queue(self) -> Pub:
         """Wrap `self._broker_client.create_pub_queue()` with instance's
@@ -112,7 +115,7 @@ class Queue:
             self._address,
             self._name,
             self._auth_token,
-            self._ack_timeout,
+            self.ack_timeout,
         )
 
     async def _create_sub_queue(self, prefetch_override: Optional[int] = None) -> Sub:
@@ -123,7 +126,7 @@ class Queue:
             self._name,
             prefetch_override if prefetch_override else self._prefetch,
             self._auth_token,
-            self._ack_timeout,
+            self.ack_timeout,
         )
 
     @contextlib.asynccontextmanager  # needs to wrap @wtt stuff to span children correctly

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -65,13 +65,13 @@ class Queue:
         self._prefetch = prefetch
         self._auth_token = auth_token
 
-        if ack_timeout is not None and ack_timeout <= 0:
-            raise ValueError("timeout must be positive")
-        self._ack_timeout = ack_timeout
 
         # publics
+        self._ack_timeout = 0
+        self.ack_timeout = ack_timeout
         self._timeout = 0
         self.timeout = timeout
+
         self.except_errors = except_errors
 
     @staticmethod
@@ -94,6 +94,17 @@ class Queue:
             raise ValueError("timeout must be positive")
         self._timeout = val
 
+    @property
+    def ack_timeout(self) -> int:
+        """Get the ack_timeout value."""
+        return self._ack_timeout
+
+    @ack_timeout.setter
+    def ack_timeout(self, val: int) -> None:
+        LOGGER.debug(f"Setting ack_timeout to {val}")
+        if val < 1:
+            raise ValueError("ack_timeout must be positive")
+        self._ack_timeout = val
     async def _create_pub_queue(self) -> Pub:
         """Wrap `self._broker_client.create_pub_queue()` with instance's
         config."""

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -56,6 +56,7 @@ class Queue:
         prefetch: int = 1,
         timeout: int = 60,
         ack_timeout: Optional[int] = None,
+        inactivity_timeout: Optional[int] = None,
         except_errors: bool = True,
         auth_token: str = "",
     ) -> None:
@@ -73,6 +74,9 @@ class Queue:
         #
         self._ack_timeout = ack_timeout
         self.ack_timeout = ack_timeout
+        #
+        self._inactivity_timeout = inactivity_timeout
+        self.inactivity_timeout = inactivity_timeout
 
         # others
         self.except_errors = except_errors
@@ -108,6 +112,19 @@ class Queue:
         if val is not None and val < 1:
             raise ValueError("ack_timeout must be positive or None")
         self._ack_timeout = val
+
+    @property
+    def inactivity_timeout(self) -> Optional[int]:
+        """Get the inactivity_timeout value."""
+        return self._inactivity_timeout
+
+    @inactivity_timeout.setter
+    def inactivity_timeout(self, val: Optional[int]) -> None:
+        LOGGER.debug(f"Setting inactivity_timeout to {val}")
+        if val is not None and val < 1:
+            raise ValueError("inactivity_timeout must be positive or None")
+        self._inactivity_timeout = val
+
     async def _create_pub_queue(self) -> Pub:
         """Wrap `self._broker_client.create_pub_queue()` with instance's
         config."""
@@ -116,6 +133,7 @@ class Queue:
             self._name,
             self._auth_token,
             self.ack_timeout,
+            self.inactivity_timeout,  # not used by all broker clients
         )
 
     async def _create_sub_queue(self, prefetch_override: Optional[int] = None) -> Sub:
@@ -127,6 +145,7 @@ class Queue:
             prefetch_override if prefetch_override else self._prefetch,
             self._auth_token,
             self.ack_timeout,
+            self.inactivity_timeout,  # not used by all broker clients
         )
 
     @contextlib.asynccontextmanager  # needs to wrap @wtt stuff to span children correctly

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -22,11 +22,11 @@ pika==1.3.1
     # via oms-mqclient (setup.py)
 pulsar-client==3.1.0
     # via oms-mqclient (setup.py)
-requests==2.28.2
+requests==2.30.0
     # via wipac-dev-tools
 typing-extensions==4.5.0
     # via wipac-dev-tools
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools==1.6.15
     # via oms-mqclient (setup.py)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=dev --output-file=requirements-dev.txt
 #
-asyncstdlib==3.10.6
+asyncstdlib==3.10.7
     # via oms-mqclient (setup.py)
 certifi==2022.12.7
     # via requests
@@ -39,7 +39,7 @@ pytest-asyncio==0.21.0
     # via oms-mqclient (setup.py)
 pytest-mock==3.10.0
     # via oms-mqclient (setup.py)
-requests==2.28.2
+requests==2.30.0
     # via wipac-dev-tools
 tomli==2.0.1
     # via
@@ -49,7 +49,7 @@ typing-extensions==4.5.0
     # via
     #   mypy
     #   wipac-dev-tools
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools==1.6.15
     # via oms-mqclient (setup.py)

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -44,7 +44,7 @@ pypng==0.20220715.0
     # via qrcode
 qrcode==7.4.2
     # via wipac-rest-tools
-requests==2.28.2
+requests==2.30.0
     # via
     #   requests-futures
     #   wipac-dev-tools
@@ -60,20 +60,20 @@ typing-extensions==4.5.0
     # via
     #   qrcode
     #   wipac-dev-tools
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools==1.6.15
     # via
     #   oms-mqclient (setup.py)
     #   wipac-keycloak-rest-services
     #   wipac-rest-tools
-wipac-keycloak-rest-services==1.3.7
+wipac-keycloak-rest-services==1.3.8
     # via oms-mqclient (setup.py)
 wipac-rest-tools==1.4.18
     # via
     #   oms-mqclient (setup.py)
     #   wipac-keycloak-rest-services
-yarl==1.9.1
+yarl==1.9.2
     # via
     #   aio-pika
     #   aiormq

--- a/requirements-nats.txt
+++ b/requirements-nats.txt
@@ -16,11 +16,11 @@ nats-py[nkeys]==2.2.0
     # via oms-mqclient (setup.py)
 nkeys==0.1.0
     # via nats-py
-requests==2.28.2
+requests==2.30.0
     # via wipac-dev-tools
 typing-extensions==4.5.0
     # via wipac-dev-tools
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools==1.6.15
     # via oms-mqclient (setup.py)

--- a/requirements-pulsar.txt
+++ b/requirements-pulsar.txt
@@ -14,11 +14,11 @@ idna==3.4
     # via requests
 pulsar-client==3.1.0
     # via oms-mqclient (setup.py)
-requests==2.28.2
+requests==2.30.0
     # via wipac-dev-tools
 typing-extensions==4.5.0
     # via wipac-dev-tools
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools==1.6.15
     # via oms-mqclient (setup.py)

--- a/requirements-rabbitmq.txt
+++ b/requirements-rabbitmq.txt
@@ -12,11 +12,11 @@ idna==3.4
     # via requests
 pika==1.3.1
     # via oms-mqclient (setup.py)
-requests==2.28.2
+requests==2.30.0
     # via wipac-dev-tools
 typing-extensions==4.5.0
     # via wipac-dev-tools
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools==1.6.15
     # via oms-mqclient (setup.py)

--- a/requirements-telemetry.txt
+++ b/requirements-telemetry.txt
@@ -56,7 +56,7 @@ protobuf==3.20.3
     #   googleapis-common-protos
     #   opentelemetry-proto
     #   wipac-telemetry
-requests==2.28.2
+requests==2.30.0
     # via
     #   opentelemetry-exporter-otlp-proto-http
     #   wipac-dev-tools
@@ -69,7 +69,7 @@ typing-extensions==4.5.0
     #   opentelemetry-sdk
     #   wipac-dev-tools
     #   wipac-telemetry
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools==1.6.15
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,11 +10,11 @@ charset-normalizer==3.1.0
     # via requests
 idna==3.4
     # via requests
-requests==2.28.2
+requests==2.30.0
     # via wipac-dev-tools
 typing-extensions==4.5.0
     # via wipac-dev-tools
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools==1.6.15
     # via oms-mqclient (setup.py)


### PR DESCRIPTION
Adds a parameter to `Queue`, `inactivity_timeout`. This is used by the rabbitmq backend. RabbitMQ's `heartbeat` time compromises both waiting for an ack/nack _and_ between messages "pulls". So if the generator is exited