### PR TITLE
Okay to Close an Already Closed Connection

### DIFF
--- a/mqclient/broker_client_interface.py
+++ b/mqclient/broker_client_interface.py
@@ -22,10 +22,6 @@ class ClosingFailedException(MQClientException):
     """Raised when a `close()` fails."""
 
 
-class AlreadyClosedException(ClosingFailedException):
-    """Raised when a `close()` fails on an already closed interface."""
-
-
 class AckException(MQClientException):
     """Raised when there's a problem with acking."""
 

--- a/mqclient/broker_clients/apachepulsar.py
+++ b/mqclient/broker_clients/apachepulsar.py
@@ -10,7 +10,6 @@ import pulsar  # type: ignore
 
 from .. import broker_client_interface, log_msgs
 from ..broker_client_interface import (
-    AlreadyClosedException,
     ClosingFailedException,
     Message,
     MQClientException,
@@ -69,7 +68,8 @@ class Pulsar(RawQueue):
         except Exception as e:
             # https://github.com/apache/pulsar/issues/3127
             if str(e) == "Pulsar error: AlreadyClosed":
-                raise AlreadyClosedException(str(e)) from e
+                LOGGER.warning("Attempted to close a connection that is already closed")
+                return
             raise ClosingFailedException(str(e)) from e
 
 

--- a/mqclient/broker_clients/rabbitmq.py
+++ b/mqclient/broker_clients/rabbitmq.py
@@ -9,7 +9,6 @@ import pika  # type: ignore
 
 from .. import broker_client_interface, log_msgs
 from ..broker_client_interface import (
-    AlreadyClosedException,
     ClosingFailedException,
     ConnectingFailedException,
     Message,
@@ -125,7 +124,8 @@ class RabbitMQ(RawQueue):
         if not self.connection:
             raise ClosingFailedException("No connection to close.")
         if self.connection.is_closed:
-            raise AlreadyClosedException()
+            LOGGER.warning("Attempted to close a connection that is already closed")
+            return
 
         try:
             # self.channel.cancel() -- done by self.connection.close()


### PR DESCRIPTION
Closing an already closed connection will no longer raise an exception. Previously, this covered up the actual error in the logs. A warning is now logged instead.