### PR TITLE
`ManualQueueSubResource` Tracking Fix 

### DIFF
--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -59,7 +59,7 @@ jobs:
           github.ref_type == 'branch' &&
           format('refs/heads/{0}', github.event.repository.default_branch) != github.ref
         name: wipac-dev-py-setup-action (only for non-dependabot non-default branches)
-        uses: WIPACrepo/wipac-dev-py-setup-action@v2.2
+        uses: WIPACrepo/wipac-dev-py-setup-action@v2.4
         with:
           base-keywords: "WIPAC IceCube"
 

--- a/dependencies-dev.log
+++ b/dependencies-dev.log
@@ -20,7 +20,7 @@ iniconfig==2.0.0
     # via pytest
 mock==5.1.0
     # via oms-mqclient (setup.py)
-mypy==1.4.1
+mypy==1.5.1
     # via oms-mqclient (setup.py)
 mypy-extensions==1.0.0
     # via mypy

--- a/dependencies-integration.log
+++ b/dependencies-integration.log
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=integration --output-file=dependencies-integration.log
 #
-aio-pika==9.1.5
+aio-pika==9.2.2
     # via wipac-keycloak-rest-services
 aiormq==6.7.7
     # via aio-pika
@@ -16,9 +16,9 @@ cffi==1.15.1
     # via cryptography
 charset-normalizer==3.2.0
     # via requests
-cryptography==41.0.2
+cryptography==41.0.3
     # via pyjwt
-dnspython==2.4.1
+dnspython==2.4.2
     # via pymongo
 execnet==2.0.2
     # via pytest-xdist
@@ -46,7 +46,7 @@ pycparser==2.21
     # via cffi
 pyjwt[crypto]==2.8.0
     # via wipac-rest-tools
-pymongo==4.4.1
+pymongo==4.5.0
     # via motor
 pypng==0.20220715.0
     # via qrcode
@@ -64,12 +64,14 @@ requests==2.31.0
     #   wipac-rest-tools
 requests-futures==1.0.1
     # via wipac-rest-tools
-tornado==6.3.2
+tornado==6.3.3
     # via wipac-rest-tools
 typing-extensions==4.7.1
     # via
     #   qrcode
     #   wipac-dev-tools
+unidecode==1.3.6
+    # via wipac-keycloak-rest-services
 urllib3==2.0.4
     # via requests
 wipac-dev-tools==1.6.16
@@ -77,9 +79,9 @@ wipac-dev-tools==1.6.16
     #   oms-mqclient (setup.py)
     #   wipac-keycloak-rest-services
     #   wipac-rest-tools
-wipac-keycloak-rest-services==1.4.18
+wipac-keycloak-rest-services==1.4.37
     # via oms-mqclient (setup.py)
-wipac-rest-tools==1.4.20
+wipac-rest-tools==1.5.2
     # via
     #   oms-mqclient (setup.py)
     #   wipac-keycloak-rest-services

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=mypy --output-file=dependencies-mypy.log
 #
-aio-pika==9.1.5
+aio-pika==9.2.2
     # via wipac-keycloak-rest-services
 aiormq==6.7.7
     # via aio-pika
@@ -26,13 +26,13 @@ coloredlogs==15.0.1
     # via
     #   oms-mqclient (setup.py)
     #   wipac-telemetry
-cryptography==41.0.2
+cryptography==41.0.3
     # via pyjwt
 deprecated==1.2.14
     # via
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-http
-dnspython==2.4.1
+dnspython==2.4.2
     # via pymongo
 ed25519==1.5
     # via nkeys
@@ -42,7 +42,7 @@ googleapis-common-protos==1.56.2
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.56.2
+grpcio==1.57.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -62,7 +62,7 @@ motor==3.2.0
     # via wipac-keycloak-rest-services
 multidict==6.0.4
     # via yarl
-mypy==1.4.1
+mypy==1.5.1
     # via oms-mqclient (setup.py)
 mypy-extensions==1.0.0
     # via mypy
@@ -120,7 +120,7 @@ pycparser==2.21
     # via cffi
 pyjwt[crypto]==2.8.0
     # via wipac-rest-tools
-pymongo==4.4.1
+pymongo==4.5.0
     # via motor
 pypng==0.20220715.0
     # via qrcode
@@ -151,7 +151,7 @@ six==1.16.0
     # via thrift
 thrift==0.16.0
     # via opentelemetry-exporter-jaeger-thrift
-tornado==6.3.2
+tornado==6.3.3
     # via wipac-rest-tools
 typing-extensions==4.7.1
     # via
@@ -160,6 +160,8 @@ typing-extensions==4.7.1
     #   qrcode
     #   wipac-dev-tools
     #   wipac-telemetry
+unidecode==1.3.6
+    # via wipac-keycloak-rest-services
 urllib3==2.0.4
     # via requests
 wipac-dev-tools==1.6.16
@@ -168,9 +170,9 @@ wipac-dev-tools==1.6.16
     #   wipac-keycloak-rest-services
     #   wipac-rest-tools
     #   wipac-telemetry
-wipac-keycloak-rest-services==1.4.18
+wipac-keycloak-rest-services==1.4.37
     # via oms-mqclient (setup.py)
-wipac-rest-tools==1.4.20
+wipac-rest-tools==1.5.2
     # via
     #   oms-mqclient (setup.py)
     #   wipac-keycloak-rest-services

--- a/dependencies-telemetry.log
+++ b/dependencies-telemetry.log
@@ -20,7 +20,7 @@ googleapis-common-protos==1.56.2
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.56.2
+grpcio==1.57.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs

--- a/mqclient/broker_client_interface.py
+++ b/mqclient/broker_client_interface.py
@@ -2,6 +2,7 @@
 
 
 import pickle
+import uuid
 from enum import Enum, auto
 from typing import Any, AsyncGenerator, Dict, Optional, Union
 
@@ -58,6 +59,9 @@ class Message:
 
         self._data = None
         self._headers = None
+
+        # set for special purposes since msg_id is not unique on redelivery
+        self.uuid = int(uuid.uuid4())
 
     def __repr__(self) -> str:
         """Return string of basic properties/attributes."""

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -459,7 +459,7 @@ class ManualQueueSubResource:
         while True:
             for sub in self._subs:
                 if raw_msg := await self._get(sub):  # got message from sub -> done
-                    self._subs[sub].append(id(raw_msg))
+                    self._subs[sub].append(raw_msg.uuid)
                     break
             else:  # no sub gave a message (didn't break) -> try w/ new sub
                 LOGGER.debug("no sub got a message -- trying w/ new sub")
@@ -473,7 +473,7 @@ class ManualQueueSubResource:
                 LOGGER.debug(
                     f"new sub got a message -- now using {len(self._subs)} subs"
                 )
-                self._subs[newb] = [id(raw_msg)]
+                self._subs[newb] = [raw_msg.uuid]
 
             LOGGER.debug(
                 f"{len(self._subs)} subs: {[len(msgs) for msgs in self._subs.values()]}"
@@ -491,7 +491,7 @@ class ManualQueueSubResource:
         )
 
     def _get_sub(self, msg: Message) -> Sub:
-        subs = [s for s, addrs in self._subs.items() if id(msg) in addrs]
+        subs = [s for s, addrs in self._subs.items() if msg.uuid in addrs]
         if not subs:
             raise ValueError("message cannot be mapped to a sub")
         elif len(subs) != 1:

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -462,13 +462,22 @@ class ManualQueueSubResource:
                     self._subs[sub].append(id(raw_msg))
                     break
             else:  # no sub gave a message (didn't break) -> try w/ new sub
+                LOGGER.debug("no sub got a message -- trying w/ new sub")
                 newb = await self.queue._create_sub_queue()
                 # keep connection open for other unacked messages
                 newb.connection_can_have_multiple_unacked_messages = True
                 if not (raw_msg := await self._get(newb)):  # no message -> close & exit
+                    LOGGER.debug("new sub had no message -- closing it...")
                     await newb.close()
                     return
+                LOGGER.debug(
+                    f"new sub got a message -- now using {len(self._subs)} subs"
+                )
                 self._subs[newb] = [id(raw_msg)]
+
+            LOGGER.debug(
+                f"{len(self._subs)} subs: {[len(msgs) for msgs in self._subs.values()]}"
+            )
 
             msg = add_span_link(raw_msg)  # got a message -> link and proceed
             LOGGER.info(f"Received Message: {_message_size_message(msg)}")


### PR DESCRIPTION
This solves the issue of tracking messages uniquely even if a `Message` instance is garbage collected.

Before, the `ManualQueueSubResource` used multiple subs and managed a mapping between each sub and list of `Message`s. This mapping used python's `id()` for each `Message` instance. This mapping is needed to ack/nack. This is fine for a vast majority of situations, but if a Message is garbage collected, python may reuse the `id()` value.