### PR TITLE
Allow Reentering `ManualQueueSubResource.iter_messages()`

### DIFF
--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -12,7 +12,6 @@ from . import broker_client_manager
 from . import telemetry as wtt
 from .broker_client_interface import (
     AckException,
-    ClosingFailedException,
     Message,
     MQClientException,
     NackException,


### PR DESCRIPTION
Re-entering `ManualQueueSubResource.iter_messages()` will no longer make a new `Sub` instance