### PR TITLE
`rabbitmq`: Don't Keep Unlimited Dry Channels

### DIFF
--- a/dependencies-all.log
+++ b/dependencies-all.log
@@ -6,18 +6,18 @@
 ########################################################################
 #  pip freeze
 ########################################################################
-certifi==2023.7.22
+certifi==2023.11.17
 charset-normalizer==3.3.2
 ed25519==1.5
-idna==3.4
+idna==3.6
 nats-py==2.6.0
 nkeys==0.1.0
 pika==1.3.2
 pulsar-client==3.1.0
 requests==2.31.0
 typing_extensions==4.8.0
-urllib3==2.0.7
-wipac-dev-tools==1.7.1
+urllib3==2.1.0
+wipac-dev-tools==1.8.2
 ########################################################################
 #  pipdeptree
 ########################################################################
@@ -25,17 +25,17 @@ nats-py==2.6.0
 nkeys==0.1.0
 └── ed25519 [required: Any, installed: 1.5]
 oms-mqclient
-└── wipac-dev-tools [required: Any, installed: 1.7.1]
+└── wipac-dev-tools [required: Any, installed: 1.8.2]
     ├── requests [required: Any, installed: 2.31.0]
-    │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+    │   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
     │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.4]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+    │   ├── idna [required: >=2.5,<4, installed: 3.6]
+    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
     └── typing-extensions [required: Any, installed: 4.8.0]
 pika==1.3.2
 pip==23.2.1
-pipdeptree==2.13.0
+pipdeptree==2.13.1
 pulsar-client==3.1.0
-└── certifi [required: Any, installed: 2023.7.22]
+└── certifi [required: Any, installed: 2023.11.17]
 setuptools==65.5.1
-wheel==0.41.2
+wheel==0.41.3

--- a/dependencies-dev.log
+++ b/dependencies-dev.log
@@ -7,14 +7,14 @@
 #  pip freeze
 ########################################################################
 asyncstdlib==3.10.9
-certifi==2023.7.22
+certifi==2023.11.17
 charset-normalizer==3.3.2
 coloredlogs==15.0.1
 humanfriendly==10.0
-idna==3.4
+idna==3.6
 iniconfig==2.0.0
 mock==5.1.0
-mypy==1.6.1
+mypy==1.7.1
 mypy-extensions==1.0.0
 packaging==23.2
 pluggy==1.3.0
@@ -23,8 +23,8 @@ pytest-asyncio==0.21.1
 pytest-mock==3.12.0
 requests==2.31.0
 typing_extensions==4.8.0
-urllib3==2.0.7
-wipac-dev-tools==1.7.1
+urllib3==2.1.0
+wipac-dev-tools==1.8.2
 ########################################################################
 #  pipdeptree
 ########################################################################
@@ -32,19 +32,19 @@ asyncstdlib==3.10.9
 coloredlogs==15.0.1
 └── humanfriendly [required: >=9.1, installed: 10.0]
 mock==5.1.0
-mypy==1.6.1
+mypy==1.7.1
 ├── mypy-extensions [required: >=1.0.0, installed: 1.0.0]
 └── typing-extensions [required: >=4.1.0, installed: 4.8.0]
 oms-mqclient
-└── wipac-dev-tools [required: Any, installed: 1.7.1]
+└── wipac-dev-tools [required: Any, installed: 1.8.2]
     ├── requests [required: Any, installed: 2.31.0]
-    │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+    │   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
     │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.4]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+    │   ├── idna [required: >=2.5,<4, installed: 3.6]
+    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
     └── typing-extensions [required: Any, installed: 4.8.0]
 pip==23.2.1
-pipdeptree==2.13.0
+pipdeptree==2.13.1
 pytest-asyncio==0.21.1
 └── pytest [required: >=7.0.0, installed: 7.4.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
@@ -56,4 +56,4 @@ pytest-mock==3.12.0
     ├── packaging [required: Any, installed: 23.2]
     └── pluggy [required: >=0.12,<2.0, installed: 1.3.0]
 setuptools==65.5.1
-wheel==0.41.2
+wheel==0.41.3

--- a/dependencies-integration.log
+++ b/dependencies-integration.log
@@ -6,92 +6,92 @@
 ########################################################################
 #  pip freeze
 ########################################################################
-aio-pika==9.3.0
+aio-pika==9.3.1
 aiormq==6.7.7
 cachetools==5.3.2
-certifi==2023.7.22
+certifi==2023.11.17
 cffi==1.16.0
 charset-normalizer==3.3.2
-cryptography==41.0.5
+cryptography==41.0.7
 dnspython==2.4.2
 execnet==2.0.2
-idna==3.4
+idna==3.6
 iniconfig==2.0.0
 ldap3==2.9.1
-motor==3.3.1
+motor==3.3.2
 multidict==6.0.4
 packaging==23.2
 pamqp==3.2.1
 pluggy==1.3.0
-pyasn1==0.5.0
+pyasn1==0.5.1
 pycparser==2.21
 PyJWT==2.8.0
-pymongo==4.5.0
+pymongo==4.6.1
 pypng==0.20220715.0
 pytest==7.4.3
-pytest-xdist==3.3.1
+pytest-xdist==3.5.0
 qrcode==7.4.2
 requests==2.31.0
 requests-futures==1.0.1
-tornado==6.3.3
+tornado==6.4
 typing_extensions==4.8.0
 Unidecode==1.3.7
-urllib3==2.0.7
-wipac-dev-tools==1.7.1
-wipac-keycloak-rest-services==1.4.45
+urllib3==2.1.0
+wipac-dev-tools==1.8.2
+wipac-keycloak-rest-services==1.4.49
 wipac-rest-tools==1.6.0
-yarl==1.9.2
+yarl==1.9.3
 ########################################################################
 #  pipdeptree
 ########################################################################
-cryptography==41.0.5
+cryptography==41.0.7
 └── cffi [required: >=1.12, installed: 1.16.0]
     └── pycparser [required: Any, installed: 2.21]
 oms-mqclient
-└── wipac-dev-tools [required: Any, installed: 1.7.1]
+└── wipac-dev-tools [required: Any, installed: 1.8.2]
     ├── requests [required: Any, installed: 2.31.0]
-    │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+    │   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
     │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.4]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+    │   ├── idna [required: >=2.5,<4, installed: 3.6]
+    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
     └── typing-extensions [required: Any, installed: 4.8.0]
 pip==23.2.1
-pipdeptree==2.13.0
-pytest-xdist==3.3.1
+pipdeptree==2.13.1
+pytest-xdist==3.5.0
 ├── execnet [required: >=1.1, installed: 2.0.2]
 └── pytest [required: >=6.2.0, installed: 7.4.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 23.2]
     └── pluggy [required: >=0.12,<2.0, installed: 1.3.0]
 setuptools==65.5.1
-wheel==0.41.2
-wipac-keycloak-rest-services==1.4.45
-├── aio-pika [required: Any, installed: 9.3.0]
+wheel==0.41.3
+wipac-keycloak-rest-services==1.4.49
+├── aio-pika [required: Any, installed: 9.3.1]
 │   ├── aiormq [required: >=6.7.7,<6.8.0, installed: 6.7.7]
 │   │   ├── pamqp [required: ==3.2.1, installed: 3.2.1]
-│   │   └── yarl [required: Any, installed: 1.9.2]
-│   │       ├── idna [required: >=2.0, installed: 3.4]
+│   │   └── yarl [required: Any, installed: 1.9.3]
+│   │       ├── idna [required: >=2.0, installed: 3.6]
 │   │       └── multidict [required: >=4.0, installed: 6.0.4]
-│   └── yarl [required: Any, installed: 1.9.2]
-│       ├── idna [required: >=2.0, installed: 3.4]
+│   └── yarl [required: Any, installed: 1.9.3]
+│       ├── idna [required: >=2.0, installed: 3.6]
 │       └── multidict [required: >=4.0, installed: 6.0.4]
 ├── ldap3 [required: Any, installed: 2.9.1]
-│   └── pyasn1 [required: >=0.4.6, installed: 0.5.0]
-├── motor [required: Any, installed: 3.3.1]
-│   └── pymongo [required: >=4.5,<5, installed: 4.5.0]
+│   └── pyasn1 [required: >=0.4.6, installed: 0.5.1]
+├── motor [required: Any, installed: 3.3.2]
+│   └── pymongo [required: >=4.5,<5, installed: 4.6.1]
 │       └── dnspython [required: >=1.16.0,<3.0.0, installed: 2.4.2]
 ├── requests [required: Any, installed: 2.31.0]
-│   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+│   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
 │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-│   ├── idna [required: >=2.5,<4, installed: 3.4]
-│   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+│   ├── idna [required: >=2.5,<4, installed: 3.6]
+│   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
 ├── Unidecode [required: Any, installed: 1.3.7]
-├── wipac-dev-tools [required: Any, installed: 1.7.1]
+├── wipac-dev-tools [required: Any, installed: 1.8.2]
 │   ├── requests [required: Any, installed: 2.31.0]
-│   │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+│   │   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
 │   │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-│   │   ├── idna [required: >=2.5,<4, installed: 3.4]
-│   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+│   │   ├── idna [required: >=2.5,<4, installed: 3.6]
+│   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
 │   └── typing-extensions [required: Any, installed: 4.8.0]
 └── wipac-rest-tools [required: Any, installed: 1.6.0]
     ├── cachetools [required: Any, installed: 5.3.2]
@@ -100,22 +100,22 @@ wipac-keycloak-rest-services==1.4.45
     │   ├── pypng [required: Any, installed: 0.20220715.0]
     │   └── typing-extensions [required: Any, installed: 4.8.0]
     ├── requests [required: Any, installed: 2.31.0]
-    │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+    │   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
     │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.4]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+    │   ├── idna [required: >=2.5,<4, installed: 3.6]
+    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
     ├── requests-futures [required: Any, installed: 1.0.1]
     │   └── requests [required: >=1.2.0, installed: 2.31.0]
-    │       ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+    │       ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
     │       ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │       ├── idna [required: >=2.5,<4, installed: 3.4]
-    │       └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
-    ├── tornado [required: Any, installed: 6.3.3]
-    ├── urllib3 [required: >=2.0.4, installed: 2.0.7]
-    └── wipac-dev-tools [required: Any, installed: 1.7.1]
+    │       ├── idna [required: >=2.5,<4, installed: 3.6]
+    │       └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
+    ├── tornado [required: Any, installed: 6.4]
+    ├── urllib3 [required: >=2.0.4, installed: 2.1.0]
+    └── wipac-dev-tools [required: Any, installed: 1.8.2]
         ├── requests [required: Any, installed: 2.31.0]
-        │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+        │   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
         │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-        │   ├── idna [required: >=2.5,<4, installed: 3.4]
-        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+        │   ├── idna [required: >=2.5,<4, installed: 3.6]
+        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
         └── typing-extensions [required: Any, installed: 4.8.0]

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -6,101 +6,101 @@
 ########################################################################
 #  pip freeze
 ########################################################################
-aio-pika==9.3.0
+aio-pika==9.3.1
 aiormq==6.7.7
 asyncstdlib==3.10.9
 backoff==2.2.1
 cachetools==5.3.2
-certifi==2023.7.22
+certifi==2023.11.17
 cffi==1.16.0
 charset-normalizer==3.3.2
 coloredlogs==15.0.1
-cryptography==41.0.5
+cryptography==41.0.7
 Deprecated==1.2.14
 dnspython==2.4.2
 ed25519==1.5
 execnet==2.0.2
-googleapis-common-protos==1.56.2
-grpcio==1.59.2
+googleapis-common-protos==1.59.1
+grpcio==1.59.3
 humanfriendly==10.0
-idna==3.4
+idna==3.6
 importlib-metadata==6.8.0
 iniconfig==2.0.0
 ldap3==2.9.1
 mock==5.1.0
-motor==3.3.1
+motor==3.3.2
 multidict==6.0.4
-mypy==1.6.1
+mypy==1.7.1
 mypy-extensions==1.0.0
 nats-py==2.6.0
 nkeys==0.1.0
-opentelemetry-api==1.20.0
-opentelemetry-exporter-jaeger==1.20.0
-opentelemetry-exporter-jaeger-proto-grpc==1.20.0
-opentelemetry-exporter-jaeger-thrift==1.20.0
-opentelemetry-exporter-otlp-proto-common==1.20.0
-opentelemetry-exporter-otlp-proto-http==1.20.0
-opentelemetry-proto==1.20.0
-opentelemetry-sdk==1.20.0
-opentelemetry-semantic-conventions==0.41b0
+opentelemetry-api==1.21.0
+opentelemetry-exporter-jaeger==1.21.0
+opentelemetry-exporter-jaeger-proto-grpc==1.21.0
+opentelemetry-exporter-jaeger-thrift==1.21.0
+opentelemetry-exporter-otlp-proto-common==1.21.0
+opentelemetry-exporter-otlp-proto-http==1.21.0
+opentelemetry-proto==1.21.0
+opentelemetry-sdk==1.21.0
+opentelemetry-semantic-conventions==0.42b0
 packaging==23.2
 pamqp==3.2.1
 pika==1.3.2
 pluggy==1.3.0
-protobuf==3.20.3
+protobuf==4.25.1
 pulsar-client==3.1.0
-pyasn1==0.5.0
+pyasn1==0.5.1
 pycparser==2.21
 PyJWT==2.8.0
-pymongo==4.5.0
+pymongo==4.6.1
 pypng==0.20220715.0
 pytest==7.4.3
 pytest-asyncio==0.21.1
 pytest-mock==3.12.0
-pytest-xdist==3.3.1
+pytest-xdist==3.5.0
 qrcode==7.4.2
 requests==2.31.0
 requests-futures==1.0.1
 six==1.16.0
 thrift==0.16.0
-tornado==6.3.3
+tornado==6.4
 typing_extensions==4.8.0
 Unidecode==1.3.7
-urllib3==2.0.7
-wipac-dev-tools==1.7.1
-wipac-keycloak-rest-services==1.4.45
+urllib3==2.1.0
+wipac-dev-tools==1.8.2
+wipac-keycloak-rest-services==1.4.49
 wipac-rest-tools==1.6.0
 wipac-telemetry==0.3.0
-wrapt==1.15.0
-yarl==1.9.2
+wrapt==1.16.0
+yarl==1.9.3
 zipp==3.17.0
 ########################################################################
 #  pipdeptree
 ########################################################################
 asyncstdlib==3.10.9
-cryptography==41.0.5
+cryptography==41.0.7
 └── cffi [required: >=1.12, installed: 1.16.0]
     └── pycparser [required: Any, installed: 2.21]
 mock==5.1.0
-mypy==1.6.1
+mypy==1.7.1
 ├── mypy-extensions [required: >=1.0.0, installed: 1.0.0]
 └── typing-extensions [required: >=4.1.0, installed: 4.8.0]
 nats-py==2.6.0
 nkeys==0.1.0
 └── ed25519 [required: Any, installed: 1.5]
 oms-mqclient
-└── wipac-dev-tools [required: Any, installed: 1.7.1]
+└── wipac-dev-tools [required: Any, installed: 1.8.2]
     ├── requests [required: Any, installed: 2.31.0]
-    │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+    │   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
     │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.4]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+    │   ├── idna [required: >=2.5,<4, installed: 3.6]
+    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
     └── typing-extensions [required: Any, installed: 4.8.0]
 pika==1.3.2
 pip==23.2.1
-pipdeptree==2.13.0
+pipdeptree==2.13.1
 pulsar-client==3.1.0
-└── certifi [required: Any, installed: 2023.7.22]
+└── certifi [required: Any, installed: 2023.11.17]
 pytest-asyncio==0.21.1
 └── pytest [required: >=7.0.0, installed: 7.4.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
@@ -111,41 +111,41 @@ pytest-mock==3.12.0
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 23.2]
     └── pluggy [required: >=0.12,<2.0, installed: 1.3.0]
-pytest-xdist==3.3.1
+pytest-xdist==3.5.0
 ├── execnet [required: >=1.1, installed: 2.0.2]
 └── pytest [required: >=6.2.0, installed: 7.4.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 23.2]
     └── pluggy [required: >=0.12,<2.0, installed: 1.3.0]
 setuptools==65.5.1
-wheel==0.41.2
-wipac-keycloak-rest-services==1.4.45
-├── aio-pika [required: Any, installed: 9.3.0]
+wheel==0.41.3
+wipac-keycloak-rest-services==1.4.49
+├── aio-pika [required: Any, installed: 9.3.1]
 │   ├── aiormq [required: >=6.7.7,<6.8.0, installed: 6.7.7]
 │   │   ├── pamqp [required: ==3.2.1, installed: 3.2.1]
-│   │   └── yarl [required: Any, installed: 1.9.2]
-│   │       ├── idna [required: >=2.0, installed: 3.4]
+│   │   └── yarl [required: Any, installed: 1.9.3]
+│   │       ├── idna [required: >=2.0, installed: 3.6]
 │   │       └── multidict [required: >=4.0, installed: 6.0.4]
-│   └── yarl [required: Any, installed: 1.9.2]
-│       ├── idna [required: >=2.0, installed: 3.4]
+│   └── yarl [required: Any, installed: 1.9.3]
+│       ├── idna [required: >=2.0, installed: 3.6]
 │       └── multidict [required: >=4.0, installed: 6.0.4]
 ├── ldap3 [required: Any, installed: 2.9.1]
-│   └── pyasn1 [required: >=0.4.6, installed: 0.5.0]
-├── motor [required: Any, installed: 3.3.1]
-│   └── pymongo [required: >=4.5,<5, installed: 4.5.0]
+│   └── pyasn1 [required: >=0.4.6, installed: 0.5.1]
+├── motor [required: Any, installed: 3.3.2]
+│   └── pymongo [required: >=4.5,<5, installed: 4.6.1]
 │       └── dnspython [required: >=1.16.0,<3.0.0, installed: 2.4.2]
 ├── requests [required: Any, installed: 2.31.0]
-│   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+│   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
 │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-│   ├── idna [required: >=2.5,<4, installed: 3.4]
-│   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+│   ├── idna [required: >=2.5,<4, installed: 3.6]
+│   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
 ├── Unidecode [required: Any, installed: 1.3.7]
-├── wipac-dev-tools [required: Any, installed: 1.7.1]
+├── wipac-dev-tools [required: Any, installed: 1.8.2]
 │   ├── requests [required: Any, installed: 2.31.0]
-│   │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+│   │   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
 │   │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-│   │   ├── idna [required: >=2.5,<4, installed: 3.4]
-│   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+│   │   ├── idna [required: >=2.5,<4, installed: 3.6]
+│   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
 │   └── typing-extensions [required: Any, installed: 4.8.0]
 └── wipac-rest-tools [required: Any, installed: 1.6.0]
     ├── cachetools [required: Any, installed: 5.3.2]
@@ -154,111 +154,111 @@ wipac-keycloak-rest-services==1.4.45
     │   ├── pypng [required: Any, installed: 0.20220715.0]
     │   └── typing-extensions [required: Any, installed: 4.8.0]
     ├── requests [required: Any, installed: 2.31.0]
-    │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+    │   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
     │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.4]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+    │   ├── idna [required: >=2.5,<4, installed: 3.6]
+    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
     ├── requests-futures [required: Any, installed: 1.0.1]
     │   └── requests [required: >=1.2.0, installed: 2.31.0]
-    │       ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+    │       ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
     │       ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │       ├── idna [required: >=2.5,<4, installed: 3.4]
-    │       └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
-    ├── tornado [required: Any, installed: 6.3.3]
-    ├── urllib3 [required: >=2.0.4, installed: 2.0.7]
-    └── wipac-dev-tools [required: Any, installed: 1.7.1]
+    │       ├── idna [required: >=2.5,<4, installed: 3.6]
+    │       └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
+    ├── tornado [required: Any, installed: 6.4]
+    ├── urllib3 [required: >=2.0.4, installed: 2.1.0]
+    └── wipac-dev-tools [required: Any, installed: 1.8.2]
         ├── requests [required: Any, installed: 2.31.0]
-        │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+        │   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
         │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-        │   ├── idna [required: >=2.5,<4, installed: 3.4]
-        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+        │   ├── idna [required: >=2.5,<4, installed: 3.6]
+        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
         └── typing-extensions [required: Any, installed: 4.8.0]
 wipac-telemetry==0.3.0
 ├── coloredlogs [required: Any, installed: 15.0.1]
 │   └── humanfriendly [required: >=9.1, installed: 10.0]
-├── opentelemetry-api [required: Any, installed: 1.20.0]
+├── opentelemetry-api [required: Any, installed: 1.21.0]
 │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
-│   │   └── wrapt [required: >=1.10,<2, installed: 1.15.0]
+│   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
 │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
 │       └── zipp [required: >=0.5, installed: 3.17.0]
-├── opentelemetry-exporter-jaeger [required: Any, installed: 1.20.0]
-│   ├── opentelemetry-exporter-jaeger-proto-grpc [required: ==1.20.0, installed: 1.20.0]
-│   │   ├── googleapis-common-protos [required: ~=1.52,<1.56.3, installed: 1.56.2]
-│   │   │   └── protobuf [required: >=3.15.0,<4.0.0dev, installed: 3.20.3]
-│   │   ├── grpcio [required: >=1.0.0,<2.0.0, installed: 1.59.2]
-│   │   ├── opentelemetry-api [required: ~=1.3, installed: 1.20.0]
+├── opentelemetry-exporter-jaeger [required: Any, installed: 1.21.0]
+│   ├── opentelemetry-exporter-jaeger-proto-grpc [required: ==1.21.0, installed: 1.21.0]
+│   │   ├── googleapis-common-protos [required: ~=1.52,<1.60.0, installed: 1.59.1]
+│   │   │   └── protobuf [required: >=3.19.5,<5.0.0.dev0,!=4.21.5,!=4.21.4,!=4.21.3,!=4.21.2,!=4.21.1,!=3.20.1,!=3.20.0, installed: 4.25.1]
+│   │   ├── grpcio [required: >=1.0.0,<2.0.0, installed: 1.59.3]
+│   │   ├── opentelemetry-api [required: ~=1.3, installed: 1.21.0]
 │   │   │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
-│   │   │   │   └── wrapt [required: >=1.10,<2, installed: 1.15.0]
+│   │   │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
 │   │   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
 │   │   │       └── zipp [required: >=0.5, installed: 3.17.0]
-│   │   └── opentelemetry-sdk [required: ~=1.11, installed: 1.20.0]
-│   │       ├── opentelemetry-api [required: ==1.20.0, installed: 1.20.0]
+│   │   └── opentelemetry-sdk [required: ~=1.11, installed: 1.21.0]
+│   │       ├── opentelemetry-api [required: ==1.21.0, installed: 1.21.0]
 │   │       │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
-│   │       │   │   └── wrapt [required: >=1.10,<2, installed: 1.15.0]
+│   │       │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
 │   │       │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
 │   │       │       └── zipp [required: >=0.5, installed: 3.17.0]
-│   │       ├── opentelemetry-semantic-conventions [required: ==0.41b0, installed: 0.41b0]
+│   │       ├── opentelemetry-semantic-conventions [required: ==0.42b0, installed: 0.42b0]
 │   │       └── typing-extensions [required: >=3.7.4, installed: 4.8.0]
-│   └── opentelemetry-exporter-jaeger-thrift [required: ==1.20.0, installed: 1.20.0]
-│       ├── opentelemetry-api [required: ~=1.3, installed: 1.20.0]
+│   └── opentelemetry-exporter-jaeger-thrift [required: ==1.21.0, installed: 1.21.0]
+│       ├── opentelemetry-api [required: ~=1.3, installed: 1.21.0]
 │       │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
-│       │   │   └── wrapt [required: >=1.10,<2, installed: 1.15.0]
+│       │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
 │       │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
 │       │       └── zipp [required: >=0.5, installed: 3.17.0]
-│       ├── opentelemetry-sdk [required: ~=1.11, installed: 1.20.0]
-│       │   ├── opentelemetry-api [required: ==1.20.0, installed: 1.20.0]
+│       ├── opentelemetry-sdk [required: ~=1.11, installed: 1.21.0]
+│       │   ├── opentelemetry-api [required: ==1.21.0, installed: 1.21.0]
 │       │   │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
-│       │   │   │   └── wrapt [required: >=1.10,<2, installed: 1.15.0]
+│       │   │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
 │       │   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
 │       │   │       └── zipp [required: >=0.5, installed: 3.17.0]
-│       │   ├── opentelemetry-semantic-conventions [required: ==0.41b0, installed: 0.41b0]
+│       │   ├── opentelemetry-semantic-conventions [required: ==0.42b0, installed: 0.42b0]
 │       │   └── typing-extensions [required: >=3.7.4, installed: 4.8.0]
 │       └── thrift [required: >=0.10.0, installed: 0.16.0]
 │           └── six [required: >=1.7.2, installed: 1.16.0]
-├── opentelemetry-exporter-otlp-proto-http [required: Any, installed: 1.20.0]
+├── opentelemetry-exporter-otlp-proto-http [required: Any, installed: 1.21.0]
 │   ├── backoff [required: >=1.10.0,<3.0.0, installed: 2.2.1]
 │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
-│   │   └── wrapt [required: >=1.10,<2, installed: 1.15.0]
-│   ├── googleapis-common-protos [required: ~=1.52, installed: 1.56.2]
-│   │   └── protobuf [required: >=3.15.0,<4.0.0dev, installed: 3.20.3]
-│   ├── opentelemetry-api [required: ~=1.15, installed: 1.20.0]
+│   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
+│   ├── googleapis-common-protos [required: ~=1.52, installed: 1.59.1]
+│   │   └── protobuf [required: >=3.19.5,<5.0.0.dev0,!=4.21.5,!=4.21.4,!=4.21.3,!=4.21.2,!=4.21.1,!=3.20.1,!=3.20.0, installed: 4.25.1]
+│   ├── opentelemetry-api [required: ~=1.15, installed: 1.21.0]
 │   │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
-│   │   │   └── wrapt [required: >=1.10,<2, installed: 1.15.0]
+│   │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
 │   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
 │   │       └── zipp [required: >=0.5, installed: 3.17.0]
-│   ├── opentelemetry-exporter-otlp-proto-common [required: ==1.20.0, installed: 1.20.0]
+│   ├── opentelemetry-exporter-otlp-proto-common [required: ==1.21.0, installed: 1.21.0]
 │   │   ├── backoff [required: >=1.10.0,<3.0.0, installed: 2.2.1]
-│   │   └── opentelemetry-proto [required: ==1.20.0, installed: 1.20.0]
-│   │       └── protobuf [required: >=3.19,<5.0, installed: 3.20.3]
-│   ├── opentelemetry-proto [required: ==1.20.0, installed: 1.20.0]
-│   │   └── protobuf [required: >=3.19,<5.0, installed: 3.20.3]
-│   ├── opentelemetry-sdk [required: ~=1.20.0, installed: 1.20.0]
-│   │   ├── opentelemetry-api [required: ==1.20.0, installed: 1.20.0]
+│   │   └── opentelemetry-proto [required: ==1.21.0, installed: 1.21.0]
+│   │       └── protobuf [required: >=3.19,<5.0, installed: 4.25.1]
+│   ├── opentelemetry-proto [required: ==1.21.0, installed: 1.21.0]
+│   │   └── protobuf [required: >=3.19,<5.0, installed: 4.25.1]
+│   ├── opentelemetry-sdk [required: ~=1.21.0, installed: 1.21.0]
+│   │   ├── opentelemetry-api [required: ==1.21.0, installed: 1.21.0]
 │   │   │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
-│   │   │   │   └── wrapt [required: >=1.10,<2, installed: 1.15.0]
+│   │   │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
 │   │   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
 │   │   │       └── zipp [required: >=0.5, installed: 3.17.0]
-│   │   ├── opentelemetry-semantic-conventions [required: ==0.41b0, installed: 0.41b0]
+│   │   ├── opentelemetry-semantic-conventions [required: ==0.42b0, installed: 0.42b0]
 │   │   └── typing-extensions [required: >=3.7.4, installed: 4.8.0]
 │   └── requests [required: ~=2.7, installed: 2.31.0]
-│       ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+│       ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
 │       ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-│       ├── idna [required: >=2.5,<4, installed: 3.4]
-│       └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
-├── opentelemetry-sdk [required: Any, installed: 1.20.0]
-│   ├── opentelemetry-api [required: ==1.20.0, installed: 1.20.0]
+│       ├── idna [required: >=2.5,<4, installed: 3.6]
+│       └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
+├── opentelemetry-sdk [required: Any, installed: 1.21.0]
+│   ├── opentelemetry-api [required: ==1.21.0, installed: 1.21.0]
 │   │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
-│   │   │   └── wrapt [required: >=1.10,<2, installed: 1.15.0]
+│   │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
 │   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
 │   │       └── zipp [required: >=0.5, installed: 3.17.0]
-│   ├── opentelemetry-semantic-conventions [required: ==0.41b0, installed: 0.41b0]
+│   ├── opentelemetry-semantic-conventions [required: ==0.42b0, installed: 0.42b0]
 │   └── typing-extensions [required: >=3.7.4, installed: 4.8.0]
-├── protobuf [required: Any, installed: 3.20.3]
+├── protobuf [required: Any, installed: 4.25.1]
 ├── typing-extensions [required: Any, installed: 4.8.0]
-└── wipac-dev-tools [required: Any, installed: 1.7.1]
+└── wipac-dev-tools [required: Any, installed: 1.8.2]
     ├── requests [required: Any, installed: 2.31.0]
-    │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+    │   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
     │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.4]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+    │   ├── idna [required: >=2.5,<4, installed: 3.6]
+    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
     └── typing-extensions [required: Any, installed: 4.8.0]

--- a/dependencies-nats.log
+++ b/dependencies-nats.log
@@ -6,16 +6,16 @@
 ########################################################################
 #  pip freeze
 ########################################################################
-certifi==2023.7.22
+certifi==2023.11.17
 charset-normalizer==3.3.2
 ed25519==1.5
-idna==3.4
+idna==3.6
 nats-py==2.6.0
 nkeys==0.1.0
 requests==2.31.0
 typing_extensions==4.8.0
-urllib3==2.0.7
-wipac-dev-tools==1.7.1
+urllib3==2.1.0
+wipac-dev-tools==1.8.2
 ########################################################################
 #  pipdeptree
 ########################################################################
@@ -23,14 +23,14 @@ nats-py==2.6.0
 nkeys==0.1.0
 └── ed25519 [required: Any, installed: 1.5]
 oms-mqclient
-└── wipac-dev-tools [required: Any, installed: 1.7.1]
+└── wipac-dev-tools [required: Any, installed: 1.8.2]
     ├── requests [required: Any, installed: 2.31.0]
-    │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+    │   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
     │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.4]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+    │   ├── idna [required: >=2.5,<4, installed: 3.6]
+    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
     └── typing-extensions [required: Any, installed: 4.8.0]
 pip==23.2.1
-pipdeptree==2.13.0
+pipdeptree==2.13.1
 setuptools==65.5.1
-wheel==0.41.2
+wheel==0.41.3

--- a/dependencies-pulsar.log
+++ b/dependencies-pulsar.log
@@ -6,28 +6,28 @@
 ########################################################################
 #  pip freeze
 ########################################################################
-certifi==2023.7.22
+certifi==2023.11.17
 charset-normalizer==3.3.2
-idna==3.4
+idna==3.6
 pulsar-client==3.1.0
 requests==2.31.0
 typing_extensions==4.8.0
-urllib3==2.0.7
-wipac-dev-tools==1.7.1
+urllib3==2.1.0
+wipac-dev-tools==1.8.2
 ########################################################################
 #  pipdeptree
 ########################################################################
 oms-mqclient
-└── wipac-dev-tools [required: Any, installed: 1.7.1]
+└── wipac-dev-tools [required: Any, installed: 1.8.2]
     ├── requests [required: Any, installed: 2.31.0]
-    │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+    │   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
     │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.4]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+    │   ├── idna [required: >=2.5,<4, installed: 3.6]
+    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
     └── typing-extensions [required: Any, installed: 4.8.0]
 pip==23.2.1
-pipdeptree==2.13.0
+pipdeptree==2.13.1
 pulsar-client==3.1.0
-└── certifi [required: Any, installed: 2023.7.22]
+└── certifi [required: Any, installed: 2023.11.17]
 setuptools==65.5.1
-wheel==0.41.2
+wheel==0.41.3

--- a/dependencies-rabbitmq.log
+++ b/dependencies-rabbitmq.log
@@ -6,27 +6,27 @@
 ########################################################################
 #  pip freeze
 ########################################################################
-certifi==2023.7.22
+certifi==2023.11.17
 charset-normalizer==3.3.2
-idna==3.4
+idna==3.6
 pika==1.3.2
 requests==2.31.0
 typing_extensions==4.8.0
-urllib3==2.0.7
-wipac-dev-tools==1.7.1
+urllib3==2.1.0
+wipac-dev-tools==1.8.2
 ########################################################################
 #  pipdeptree
 ########################################################################
 oms-mqclient
-└── wipac-dev-tools [required: Any, installed: 1.7.1]
+└── wipac-dev-tools [required: Any, installed: 1.8.2]
     ├── requests [required: Any, installed: 2.31.0]
-    │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+    │   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
     │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.4]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+    │   ├── idna [required: >=2.5,<4, installed: 3.6]
+    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
     └── typing-extensions [required: Any, installed: 4.8.0]
 pika==1.3.2
 pip==23.2.1
-pipdeptree==2.13.0
+pipdeptree==2.13.1
 setuptools==65.5.1
-wheel==0.41.2
+wheel==0.41.3

--- a/dependencies-telemetry.log
+++ b/dependencies-telemetry.log
@@ -7,135 +7,135 @@
 #  pip freeze
 ########################################################################
 backoff==2.2.1
-certifi==2023.7.22
+certifi==2023.11.17
 charset-normalizer==3.3.2
 coloredlogs==15.0.1
 Deprecated==1.2.14
-googleapis-common-protos==1.56.2
-grpcio==1.59.2
+googleapis-common-protos==1.59.1
+grpcio==1.59.3
 humanfriendly==10.0
-idna==3.4
+idna==3.6
 importlib-metadata==6.8.0
-opentelemetry-api==1.20.0
-opentelemetry-exporter-jaeger==1.20.0
-opentelemetry-exporter-jaeger-proto-grpc==1.20.0
-opentelemetry-exporter-jaeger-thrift==1.20.0
-opentelemetry-exporter-otlp-proto-common==1.20.0
-opentelemetry-exporter-otlp-proto-http==1.20.0
-opentelemetry-proto==1.20.0
-opentelemetry-sdk==1.20.0
-opentelemetry-semantic-conventions==0.41b0
-protobuf==3.20.3
+opentelemetry-api==1.21.0
+opentelemetry-exporter-jaeger==1.21.0
+opentelemetry-exporter-jaeger-proto-grpc==1.21.0
+opentelemetry-exporter-jaeger-thrift==1.21.0
+opentelemetry-exporter-otlp-proto-common==1.21.0
+opentelemetry-exporter-otlp-proto-http==1.21.0
+opentelemetry-proto==1.21.0
+opentelemetry-sdk==1.21.0
+opentelemetry-semantic-conventions==0.42b0
+protobuf==4.25.1
 requests==2.31.0
 six==1.16.0
 thrift==0.16.0
 typing_extensions==4.8.0
-urllib3==2.0.7
-wipac-dev-tools==1.7.1
+urllib3==2.1.0
+wipac-dev-tools==1.8.2
 wipac-telemetry==0.3.0
-wrapt==1.15.0
+wrapt==1.16.0
 zipp==3.17.0
 ########################################################################
 #  pipdeptree
 ########################################################################
 oms-mqclient
-└── wipac-dev-tools [required: Any, installed: 1.7.1]
+└── wipac-dev-tools [required: Any, installed: 1.8.2]
     ├── requests [required: Any, installed: 2.31.0]
-    │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+    │   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
     │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.4]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+    │   ├── idna [required: >=2.5,<4, installed: 3.6]
+    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
     └── typing-extensions [required: Any, installed: 4.8.0]
 pip==23.2.1
-pipdeptree==2.13.0
+pipdeptree==2.13.1
 setuptools==65.5.1
-wheel==0.41.2
+wheel==0.41.3
 wipac-telemetry==0.3.0
 ├── coloredlogs [required: Any, installed: 15.0.1]
 │   └── humanfriendly [required: >=9.1, installed: 10.0]
-├── opentelemetry-api [required: Any, installed: 1.20.0]
+├── opentelemetry-api [required: Any, installed: 1.21.0]
 │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
-│   │   └── wrapt [required: >=1.10,<2, installed: 1.15.0]
+│   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
 │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
 │       └── zipp [required: >=0.5, installed: 3.17.0]
-├── opentelemetry-exporter-jaeger [required: Any, installed: 1.20.0]
-│   ├── opentelemetry-exporter-jaeger-proto-grpc [required: ==1.20.0, installed: 1.20.0]
-│   │   ├── googleapis-common-protos [required: ~=1.52,<1.56.3, installed: 1.56.2]
-│   │   │   └── protobuf [required: >=3.15.0,<4.0.0dev, installed: 3.20.3]
-│   │   ├── grpcio [required: >=1.0.0,<2.0.0, installed: 1.59.2]
-│   │   ├── opentelemetry-api [required: ~=1.3, installed: 1.20.0]
+├── opentelemetry-exporter-jaeger [required: Any, installed: 1.21.0]
+│   ├── opentelemetry-exporter-jaeger-proto-grpc [required: ==1.21.0, installed: 1.21.0]
+│   │   ├── googleapis-common-protos [required: ~=1.52,<1.60.0, installed: 1.59.1]
+│   │   │   └── protobuf [required: >=3.19.5,<5.0.0.dev0,!=4.21.5,!=4.21.4,!=4.21.3,!=4.21.2,!=4.21.1,!=3.20.1,!=3.20.0, installed: 4.25.1]
+│   │   ├── grpcio [required: >=1.0.0,<2.0.0, installed: 1.59.3]
+│   │   ├── opentelemetry-api [required: ~=1.3, installed: 1.21.0]
 │   │   │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
-│   │   │   │   └── wrapt [required: >=1.10,<2, installed: 1.15.0]
+│   │   │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
 │   │   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
 │   │   │       └── zipp [required: >=0.5, installed: 3.17.0]
-│   │   └── opentelemetry-sdk [required: ~=1.11, installed: 1.20.0]
-│   │       ├── opentelemetry-api [required: ==1.20.0, installed: 1.20.0]
+│   │   └── opentelemetry-sdk [required: ~=1.11, installed: 1.21.0]
+│   │       ├── opentelemetry-api [required: ==1.21.0, installed: 1.21.0]
 │   │       │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
-│   │       │   │   └── wrapt [required: >=1.10,<2, installed: 1.15.0]
+│   │       │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
 │   │       │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
 │   │       │       └── zipp [required: >=0.5, installed: 3.17.0]
-│   │       ├── opentelemetry-semantic-conventions [required: ==0.41b0, installed: 0.41b0]
+│   │       ├── opentelemetry-semantic-conventions [required: ==0.42b0, installed: 0.42b0]
 │   │       └── typing-extensions [required: >=3.7.4, installed: 4.8.0]
-│   └── opentelemetry-exporter-jaeger-thrift [required: ==1.20.0, installed: 1.20.0]
-│       ├── opentelemetry-api [required: ~=1.3, installed: 1.20.0]
+│   └── opentelemetry-exporter-jaeger-thrift [required: ==1.21.0, installed: 1.21.0]
+│       ├── opentelemetry-api [required: ~=1.3, installed: 1.21.0]
 │       │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
-│       │   │   └── wrapt [required: >=1.10,<2, installed: 1.15.0]
+│       │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
 │       │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
 │       │       └── zipp [required: >=0.5, installed: 3.17.0]
-│       ├── opentelemetry-sdk [required: ~=1.11, installed: 1.20.0]
-│       │   ├── opentelemetry-api [required: ==1.20.0, installed: 1.20.0]
+│       ├── opentelemetry-sdk [required: ~=1.11, installed: 1.21.0]
+│       │   ├── opentelemetry-api [required: ==1.21.0, installed: 1.21.0]
 │       │   │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
-│       │   │   │   └── wrapt [required: >=1.10,<2, installed: 1.15.0]
+│       │   │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
 │       │   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
 │       │   │       └── zipp [required: >=0.5, installed: 3.17.0]
-│       │   ├── opentelemetry-semantic-conventions [required: ==0.41b0, installed: 0.41b0]
+│       │   ├── opentelemetry-semantic-conventions [required: ==0.42b0, installed: 0.42b0]
 │       │   └── typing-extensions [required: >=3.7.4, installed: 4.8.0]
 │       └── thrift [required: >=0.10.0, installed: 0.16.0]
 │           └── six [required: >=1.7.2, installed: 1.16.0]
-├── opentelemetry-exporter-otlp-proto-http [required: Any, installed: 1.20.0]
+├── opentelemetry-exporter-otlp-proto-http [required: Any, installed: 1.21.0]
 │   ├── backoff [required: >=1.10.0,<3.0.0, installed: 2.2.1]
 │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
-│   │   └── wrapt [required: >=1.10,<2, installed: 1.15.0]
-│   ├── googleapis-common-protos [required: ~=1.52, installed: 1.56.2]
-│   │   └── protobuf [required: >=3.15.0,<4.0.0dev, installed: 3.20.3]
-│   ├── opentelemetry-api [required: ~=1.15, installed: 1.20.0]
+│   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
+│   ├── googleapis-common-protos [required: ~=1.52, installed: 1.59.1]
+│   │   └── protobuf [required: >=3.19.5,<5.0.0.dev0,!=4.21.5,!=4.21.4,!=4.21.3,!=4.21.2,!=4.21.1,!=3.20.1,!=3.20.0, installed: 4.25.1]
+│   ├── opentelemetry-api [required: ~=1.15, installed: 1.21.0]
 │   │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
-│   │   │   └── wrapt [required: >=1.10,<2, installed: 1.15.0]
+│   │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
 │   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
 │   │       └── zipp [required: >=0.5, installed: 3.17.0]
-│   ├── opentelemetry-exporter-otlp-proto-common [required: ==1.20.0, installed: 1.20.0]
+│   ├── opentelemetry-exporter-otlp-proto-common [required: ==1.21.0, installed: 1.21.0]
 │   │   ├── backoff [required: >=1.10.0,<3.0.0, installed: 2.2.1]
-│   │   └── opentelemetry-proto [required: ==1.20.0, installed: 1.20.0]
-│   │       └── protobuf [required: >=3.19,<5.0, installed: 3.20.3]
-│   ├── opentelemetry-proto [required: ==1.20.0, installed: 1.20.0]
-│   │   └── protobuf [required: >=3.19,<5.0, installed: 3.20.3]
-│   ├── opentelemetry-sdk [required: ~=1.20.0, installed: 1.20.0]
-│   │   ├── opentelemetry-api [required: ==1.20.0, installed: 1.20.0]
+│   │   └── opentelemetry-proto [required: ==1.21.0, installed: 1.21.0]
+│   │       └── protobuf [required: >=3.19,<5.0, installed: 4.25.1]
+│   ├── opentelemetry-proto [required: ==1.21.0, installed: 1.21.0]
+│   │   └── protobuf [required: >=3.19,<5.0, installed: 4.25.1]
+│   ├── opentelemetry-sdk [required: ~=1.21.0, installed: 1.21.0]
+│   │   ├── opentelemetry-api [required: ==1.21.0, installed: 1.21.0]
 │   │   │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
-│   │   │   │   └── wrapt [required: >=1.10,<2, installed: 1.15.0]
+│   │   │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
 │   │   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
 │   │   │       └── zipp [required: >=0.5, installed: 3.17.0]
-│   │   ├── opentelemetry-semantic-conventions [required: ==0.41b0, installed: 0.41b0]
+│   │   ├── opentelemetry-semantic-conventions [required: ==0.42b0, installed: 0.42b0]
 │   │   └── typing-extensions [required: >=3.7.4, installed: 4.8.0]
 │   └── requests [required: ~=2.7, installed: 2.31.0]
-│       ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+│       ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
 │       ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-│       ├── idna [required: >=2.5,<4, installed: 3.4]
-│       └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
-├── opentelemetry-sdk [required: Any, installed: 1.20.0]
-│   ├── opentelemetry-api [required: ==1.20.0, installed: 1.20.0]
+│       ├── idna [required: >=2.5,<4, installed: 3.6]
+│       └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
+├── opentelemetry-sdk [required: Any, installed: 1.21.0]
+│   ├── opentelemetry-api [required: ==1.21.0, installed: 1.21.0]
 │   │   ├── Deprecated [required: >=1.2.6, installed: 1.2.14]
-│   │   │   └── wrapt [required: >=1.10,<2, installed: 1.15.0]
+│   │   │   └── wrapt [required: >=1.10,<2, installed: 1.16.0]
 │   │   └── importlib-metadata [required: >=6.0,<7.0, installed: 6.8.0]
 │   │       └── zipp [required: >=0.5, installed: 3.17.0]
-│   ├── opentelemetry-semantic-conventions [required: ==0.41b0, installed: 0.41b0]
+│   ├── opentelemetry-semantic-conventions [required: ==0.42b0, installed: 0.42b0]
 │   └── typing-extensions [required: >=3.7.4, installed: 4.8.0]
-├── protobuf [required: Any, installed: 3.20.3]
+├── protobuf [required: Any, installed: 4.25.1]
 ├── typing-extensions [required: Any, installed: 4.8.0]
-└── wipac-dev-tools [required: Any, installed: 1.7.1]
+└── wipac-dev-tools [required: Any, installed: 1.8.2]
     ├── requests [required: Any, installed: 2.31.0]
-    │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+    │   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
     │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.4]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+    │   ├── idna [required: >=2.5,<4, installed: 3.6]
+    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
     └── typing-extensions [required: Any, installed: 4.8.0]

--- a/dependencies.log
+++ b/dependencies.log
@@ -6,25 +6,25 @@
 ########################################################################
 #  pip freeze
 ########################################################################
-certifi==2023.7.22
+certifi==2023.11.17
 charset-normalizer==3.3.2
-idna==3.4
+idna==3.6
 requests==2.31.0
 typing_extensions==4.8.0
-urllib3==2.0.7
-wipac-dev-tools==1.7.1
+urllib3==2.1.0
+wipac-dev-tools==1.8.2
 ########################################################################
 #  pipdeptree
 ########################################################################
 oms-mqclient
-└── wipac-dev-tools [required: Any, installed: 1.7.1]
+└── wipac-dev-tools [required: Any, installed: 1.8.2]
     ├── requests [required: Any, installed: 2.31.0]
-    │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
+    │   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
     │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.4]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+    │   ├── idna [required: >=2.5,<4, installed: 3.6]
+    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
     └── typing-extensions [required: Any, installed: 4.8.0]
 pip==23.2.1
-pipdeptree==2.13.0
+pipdeptree==2.13.1
 setuptools==65.5.1
-wheel==0.41.2
+wheel==0.41.3

--- a/mqclient/broker_clients/rabbitmq.py
+++ b/mqclient/broker_clients/rabbitmq.py
@@ -364,7 +364,7 @@ class RabbitMQSub(RabbitMQ, Sub):
             except StopIteration:
                 return (None, None, None)
 
-        def infinite_channels() -> (
+        def infinite_loop_over_channels() -> (
             Iterator[pika.adapters.blocking_connection.BlockingChannel]
         ):
             # this allows self.channels to be updated,
@@ -373,7 +373,7 @@ class RabbitMQSub(RabbitMQ, Sub):
             while True:
                 yield from self.channels
 
-        inf_channels_gen = infinite_channels()
+        inf_channels_gen = infinite_loop_over_channels()
         channel = next(inf_channels_gen)  # always called manually
         n_nonempty_channels_remaining = len(self.channels)  # assume all are non-empty
 

--- a/mqclient/broker_clients/rabbitmq.py
+++ b/mqclient/broker_clients/rabbitmq.py
@@ -110,10 +110,10 @@ class RabbitMQ(RawQueue):
         self._next_channel_number = 1  # must start at 1 (not 0)
 
     def open_channel(self) -> pika.adapters.blocking_connection.BlockingChannel:
-        """Add a channel for the connection and configure."""
-        LOGGER.info(f"Adding channel to connection for '{self.queue=}'")
+        """Open a channel for the connection and configure."""
+        LOGGER.info(f"Opening channel to connection for '{self.queue=}'")
         if not self.connection:
-            raise ClosingFailedException("No connection to add channel.")
+            raise ClosingFailedException("No connection to open channel.")
 
         # give unique channel_number b/c pika has a delay on re-connections in which it will recycle a closed channel
         channel = self.connection.channel(self._next_channel_number)
@@ -132,7 +132,6 @@ class RabbitMQ(RawQueue):
             queue=self.queue, durable=True, arguments={"x-queue-type": "quorum"}
         )
 
-        # self.channels.append(channel)
         LOGGER.info(f"Opened channel '{channel.channel_number}'")
         return channel
 
@@ -151,8 +150,6 @@ class RabbitMQ(RawQueue):
         """Close connection."""
         await super().close()
 
-        # if not self.channels:
-        #     raise ClosingFailedException("No channel to close.")
         if not self.connection:
             raise ClosingFailedException("No connection to close.")
         if self.connection.is_closed:
@@ -160,8 +157,7 @@ class RabbitMQ(RawQueue):
             return
 
         try:
-            # self.channel.cancel() -- done by self.connection.close()
-            self.connection.close()
+            self.connection.close()  # also closes each channel
         except Exception as e:
             raise ClosingFailedException() from e
 
@@ -185,7 +181,7 @@ class RabbitMQPub(RabbitMQ, Pub):
         self.channel: Optional[pika.adapters.blocking_connection.BlockingChannel] = None
 
     def open_channel(self) -> pika.adapters.blocking_connection.BlockingChannel:
-        """Add a channel for the connection and configure."""
+        """Open a channel for the connection and configure."""
         if self.channel:
             raise MQClientException("RabbitMQPub instance can only have one channel")
 
@@ -285,7 +281,7 @@ class RabbitMQSub(RabbitMQ, Sub):
         ] = None
 
     def open_channel(self) -> pika.adapters.blocking_connection.BlockingChannel:
-        """Add a channel for the connection and configure.
+        """Open a channel for the connection and configure.
 
         Turn on prefetching.
         """
@@ -334,7 +330,7 @@ class RabbitMQSub(RabbitMQ, Sub):
         LOGGER.debug(log_msgs.CLOSED_SUB)
 
     @staticmethod
-    def _to_message(  # type: ignore[override]  # noqa: F821 # pylint: disable=W0221
+    def _to_message(  # noqa: F821 # pylint: disable=W0221
         method_frame: Optional[pika.spec.Basic.GetOk],
         body: Optional[Union[str, bytes]],
         channel_number: int,
@@ -378,20 +374,8 @@ class RabbitMQSub(RabbitMQ, Sub):
             except StopIteration:
                 return (None, None, None)
 
-        # def infinite_loop_over_channels() -> (
-        #     Iterator[pika.adapters.blocking_connection.BlockingChannel]
-        # ):
-        #     # this allows self.channels to be updated,
-        #     # updates are reflected on outer-loop
-        #     # itertools.cycle() does not allow updates
-        #     while True:
-        #         yield from self.channels
-
-        # inf_channels_gen = infinite_loop_over_channels()
-        # channel = next(inf_channels_gen)  # always called manually
-        # n_nonempty_channels_remaining = len(self.channels)  # assume all are non-empty
-        remaining_channels = copy.copy(self.active_channels)  # start with all
-        channel = remaining_channels[0]  # TODO - use by priority?
+        remaining_active_channels = copy.copy(self.active_channels)  # start with all
+        channel = remaining_active_channels[0]
 
         while True:
             try:
@@ -413,6 +397,7 @@ class RabbitMQSub(RabbitMQ, Sub):
             except pika.exceptions.StreamLostError as e:
                 raise MQClientException(HEARTBEAT_STREAMLOSTERROR_MSG) from e
 
+            #
             # YIELD (got a message)
             if msg := RabbitMQSub._to_message(
                 pika_msg[0],
@@ -420,57 +405,33 @@ class RabbitMQSub(RabbitMQ, Sub):
                 channel.channel_number,
             ):
                 LOGGER.debug(f"{log_msgs.GETMSG_RECEIVED_MESSAGE} ({msg.msg_id!r}).")
-                # n_nonempty_channels_remaining = len(self.channels)  # reset!
                 if channel == self.reserve_channel:
                     # if this was the reserve channel, move it to active channels
                     self.active_channels.append(self.reserve_channel)
                     self.reserve_channel = None  # no need to open a new one now
-                remaining_channels = copy.copy(self.active_channels)  # reset!
+                remaining_active_channels = copy.copy(self.active_channels)  # reset!
                 yield msg
+            #
             # DEAL WITH EMPTY CHANNEL (didn't get a message)
             else:
-                # n_nonempty_channels_remaining -= 1
-                LOGGER.debug("No message received -- switching channels...")
                 if channel == self.reserve_channel:
+                    LOGGER.debug("No message received -- tried all channels")
                     # this means our reserve channel came up empty,
                     # so there's REALLY nothing in the queue
                     LOGGER.debug(log_msgs.GETMSG_NO_MESSAGE)
-                    remaining_channels = copy.copy(self.active_channels)  # reset!
+                    remaining_active_channels = copy.copy(self.active_channels)  # reset
                     yield None
                 else:
-                    remaining_channels.remove(channel)
-                    # if n_nonempty_channels_remaining == 0:
-                    if not remaining_channels:
-                        # don't reset n_nonempty_channels_remaining so we can see if this one is empty
-                        # channel = self.open_channel()  # try it now
-                        # this new channel will be yielded by inf_channels_gen eventually
-
-                        # FIXME - this leads to MANY empty channels if the user
-                        #   keeps cycling despite coming up empty
-                        # TODO - figure way to close or limit channels, but
-                        #   consider that some ack-pending messages need to use
-                        #   the channel to ack. Keep one local mapping?
-                        #   Currently uses msg._connection_id.
-                        #   Maybe just closing a newly-opened channel will suffice?
-
+                    LOGGER.debug("No message received -- switching channels...")
+                    remaining_active_channels.remove(channel)
+                    if not remaining_active_channels:
                         # try reserve channel
                         if not self.reserve_channel:
                             self.reserve_channel = self.open_channel()
                         channel = self.reserve_channel
-
-                        # continue
-                    # elif n_nonempty_channels_remaining < 0:  # -1
-                    #     # this means our newly produced channel is empty,
-                    #     # so there's REALLY nothing in the queue
-                    #     LOGGER.debug(log_msgs.GETMSG_NO_MESSAGE)
-                    #     self.reserve_channel
-                    #     channel = next(inf_channels_gen)  # try next, next time
-                    #     # FIXME - this design still allows a lot of new channels, one per final iter...
-                    #     yield None
                     else:
-                        # channel = next(inf_channels_gen)  # try next, now
-                        channel = remaining_channels[0]  # TODO - use by priority?
-                        # continue
+                        # try next active channel
+                        channel = remaining_active_channels[0]
 
     async def get_message(
         self,
@@ -487,8 +448,6 @@ class RabbitMQSub(RabbitMQ, Sub):
         async for msg in self._iter_messages(timeout_millis, retries, retry_delay):
             # None -> timeout
             break  # get just one message
-
-        # self.channel.cancel()  # this is done by `open_sub_one()` *after* ack/nack via `close()`
 
         return msg
 

--- a/mqclient/broker_clients/rabbitmq.py
+++ b/mqclient/broker_clients/rabbitmq.py
@@ -1,5 +1,6 @@
 """Back-end using RabbitMQ."""
 
+import copy
 import functools
 import logging
 import urllib
@@ -384,7 +385,7 @@ class RabbitMQSub(RabbitMQ, Sub):
         # inf_channels_gen = infinite_loop_over_channels()
         # channel = next(inf_channels_gen)  # always called manually
         # n_nonempty_channels_remaining = len(self.channels)  # assume all are non-empty
-        remaining_channels = [c for c in self.active_channels]  # start with all
+        remaining_channels = copy.copy(self.active_channels)  # start with all
         channel = remaining_channels[0]  # TODO - use by priority?
 
         while True:
@@ -419,7 +420,7 @@ class RabbitMQSub(RabbitMQ, Sub):
                     # if this was the reserve channel, move it to active channels
                     self.active_channels.append(self.reserve_channel)
                     self.reserve_channel = None  # no need to open a new one now
-                remaining_channels = [c for c in self.active_channels]  # reset!
+                remaining_channels = copy.copy(self.active_channels)  # reset!
                 yield msg
             # DEAL WITH EMPTY CHANNEL (didn't get a message)
             else:
@@ -429,7 +430,7 @@ class RabbitMQSub(RabbitMQ, Sub):
                     # this means our reserve channel came up empty,
                     # so there's REALLY nothing in the queue
                     LOGGER.debug(log_msgs.GETMSG_NO_MESSAGE)
-                    remaining_channels = [c for c in self.active_channels]  # reset!
+                    remaining_channels = copy.copy(self.active_channels)  # reset!
                     yield None
                 else:
                     remaining_channels.remove(channel)

--- a/mqclient/broker_clients/rabbitmq.py
+++ b/mqclient/broker_clients/rabbitmq.py
@@ -8,7 +8,6 @@ from typing import (
     AsyncGenerator,
     AsyncIterator,
     Dict,
-    Iterator,
     List,
     Optional,
     Tuple,
@@ -385,7 +384,7 @@ class RabbitMQSub(RabbitMQ, Sub):
         # inf_channels_gen = infinite_loop_over_channels()
         # channel = next(inf_channels_gen)  # always called manually
         # n_nonempty_channels_remaining = len(self.channels)  # assume all are non-empty
-        remaining_channels = self.active_channels  # start with all
+        remaining_channels = [c for c in self.active_channels]  # start with all
         channel = remaining_channels[0]  # TODO - use by priority?
 
         while True:
@@ -420,7 +419,7 @@ class RabbitMQSub(RabbitMQ, Sub):
                     # if this was the reserve channel, move it to active channels
                     self.active_channels.append(self.reserve_channel)
                     self.reserve_channel = None  # no need to open a new one now
-                remaining_channels = self.active_channels  # reset!
+                remaining_channels = [c for c in self.active_channels]  # reset!
                 yield msg
             # DEAL WITH EMPTY CHANNEL (didn't get a message)
             else:
@@ -430,7 +429,7 @@ class RabbitMQSub(RabbitMQ, Sub):
                     # this means our reserve channel came up empty,
                     # so there's REALLY nothing in the queue
                     LOGGER.debug(log_msgs.GETMSG_NO_MESSAGE)
-                    remaining_channels = self.active_channels  # reset!
+                    remaining_channels = [c for c in self.active_channels]  # reset!
                     yield None
                 else:
                     remaining_channels.remove(channel)

--- a/mqclient/broker_clients/rabbitmq.py
+++ b/mqclient/broker_clients/rabbitmq.py
@@ -182,7 +182,7 @@ class RabbitMQPub(RabbitMQ, Pub):
     ) -> None:
         LOGGER.debug(f"{log_msgs.INIT_PUB} ({address}; {name})")
         super().__init__(address, name, auth_token)
-        self.channel: pika.adapters.blocking_connection.BlockingChannel = []
+        self.channel: Optional[pika.adapters.blocking_connection.BlockingChannel] = None
 
     def open_channel(self) -> pika.adapters.blocking_connection.BlockingChannel:
         """Add a channel for the connection and configure."""
@@ -206,6 +206,7 @@ class RabbitMQPub(RabbitMQ, Pub):
         """Close connection."""
         LOGGER.debug(log_msgs.CLOSING_PUB)
         await super().close()
+        self.channel = None
         LOGGER.debug(log_msgs.CLOSED_PUB)
 
     async def send_message(
@@ -326,7 +327,7 @@ class RabbitMQSub(RabbitMQ, Sub):
                 )
         if self.reserve_channel and self.reserve_channel.is_open:
             LOGGER.warning(
-                f"Reserve channel remains open after connection close: {channel.channel_number}."
+                f"Reserve channel remains open after connection close: {self.reserve_channel.channel_number}."
             )
         self.active_channels = []
         self.reserve_channel = None

--- a/mqclient/broker_clients/rabbitmq.py
+++ b/mqclient/broker_clients/rabbitmq.py
@@ -319,11 +319,15 @@ class RabbitMQSub(RabbitMQ, Sub):
         """
         LOGGER.debug(log_msgs.CLOSING_SUB)
         await super().close()
-        for channel in self.active_channels + [self.reserve_channel]:
+        for channel in self.active_channels:
             if channel.is_open:
                 LOGGER.warning(
                     f"Channel remains open after connection close: {channel.channel_number}."
                 )
+        if self.reserve_channel and self.reserve_channel.is_open:
+            LOGGER.warning(
+                f"Reserve channel remains open after connection close: {channel.channel_number}."
+            )
         self.active_channels = []
         self.reserve_channel = None
         LOGGER.debug(log_msgs.CLOSED_SUB)

--- a/tests/abstract_broker_client_tests/unit_tests.py
+++ b/tests/abstract_broker_client_tests/unit_tests.py
@@ -85,7 +85,7 @@ class BrokerClientUnitTest:
             self.broker_client, "rabbitmq.BrokerClient"
         ):  # HACK: manually set attr
             mock_con.return_value.is_closed = False
-            sub._get_channel_by_msg = lambda *args: sub.channels[0]  # type: ignore[attr-defined]
+            sub._get_channel_by_msg = lambda *args: sub.active_channels[0]  # type: ignore[attr-defined]
 
         await sub.ack_message(
             Message(12, b""),
@@ -104,7 +104,7 @@ class BrokerClientUnitTest:
             self.broker_client, "rabbitmq.BrokerClient"
         ):  # HACK: manually set attr
             mock_con.return_value.is_closed = False
-            sub._get_channel_by_msg = lambda *args: sub.channels[0]  # type: ignore[attr-defined]
+            sub._get_channel_by_msg = lambda *args: sub.active_channels[0]  # type: ignore[attr-defined]
 
         await sub.reject_message(
             Message(12, b""),


### PR DESCRIPTION
Now, when rabbitmq channels fail to receive a message, a dedicated "reserve" channel will be tried. If that channel succeded, it is added to the [rotation](https://en.wikipedia.org/wiki/Starting_pitcher#:~:text=Therefore%2C%20most%20professional%20baseball%20teams,to%20pitch%20in%20the%20rotation.). Otherwise, it is kept as a reserve and the mqclient times out.