### PR TITLE
Use JSON and `zstd` for Message Serialization [minor]

### DIFF
--- a/dependencies-all.log
+++ b/dependencies-all.log
@@ -17,19 +17,21 @@ requests==2.32.3
 typing_extensions==4.12.2
 urllib3==2.2.2
 wipac-dev-tools==1.10.6
+zstd==1.5.5.1
 ########################################################################
 #  pipdeptree
 ########################################################################
 nats-py==2.7.2
 nkeys==0.2.0
 oms-mqclient
-└── wipac-dev-tools [required: Any, installed: 1.10.6]
-    ├── requests [required: Any, installed: 2.32.3]
-    │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
-    │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.7]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
-    └── typing_extensions [required: Any, installed: 4.12.2]
+├── wipac-dev-tools [required: Any, installed: 1.10.6]
+│   ├── requests [required: Any, installed: 2.32.3]
+│   │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
+│   │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
+│   │   ├── idna [required: >=2.5,<4, installed: 3.7]
+│   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
+│   └── typing_extensions [required: Any, installed: 4.12.2]
+└── zstd [required: Any, installed: 1.5.5.1]
 pika==1.3.2
 pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]

--- a/dependencies-all.log
+++ b/dependencies-all.log
@@ -31,7 +31,7 @@ oms-mqclient
     │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
     └── typing_extensions [required: Any, installed: 4.12.2]
 pika==1.3.2
-pipdeptree==2.22.0
+pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
 └── pip [required: >=23.1.2, installed: 24.0]
 pulsar-client==3.5.0

--- a/dependencies-dev.log
+++ b/dependencies-dev.log
@@ -43,7 +43,7 @@ oms-mqclient
     │   ├── idna [required: >=2.5,<4, installed: 3.7]
     │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
     └── typing_extensions [required: Any, installed: 4.12.2]
-pipdeptree==2.22.0
+pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
 └── pip [required: >=23.1.2, installed: 24.0]
 pytest-asyncio==0.23.7

--- a/dependencies-dev.log
+++ b/dependencies-dev.log
@@ -25,6 +25,7 @@ requests==2.32.3
 typing_extensions==4.12.2
 urllib3==2.2.2
 wipac-dev-tools==1.10.6
+zstd==1.5.5.1
 ########################################################################
 #  pipdeptree
 ########################################################################
@@ -36,13 +37,14 @@ mypy==1.10.0
 ├── mypy-extensions [required: >=1.0.0, installed: 1.0.0]
 └── typing_extensions [required: >=4.1.0, installed: 4.12.2]
 oms-mqclient
-└── wipac-dev-tools [required: Any, installed: 1.10.6]
-    ├── requests [required: Any, installed: 2.32.3]
-    │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
-    │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.7]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
-    └── typing_extensions [required: Any, installed: 4.12.2]
+├── wipac-dev-tools [required: Any, installed: 1.10.6]
+│   ├── requests [required: Any, installed: 2.32.3]
+│   │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
+│   │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
+│   │   ├── idna [required: >=2.5,<4, installed: 3.7]
+│   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
+│   └── typing_extensions [required: Any, installed: 4.12.2]
+└── zstd [required: Any, installed: 1.5.5.1]
 pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
 └── pip [required: >=23.1.2, installed: 24.0]

--- a/dependencies-integration.log
+++ b/dependencies-integration.log
@@ -42,6 +42,7 @@ wipac-dev-tools==1.10.6
 wipac-keycloak-rest-services==1.4.102
 wipac-rest-tools==1.7.5
 yarl==1.9.4
+zstd==1.5.5.1
 ########################################################################
 #  pipdeptree
 ########################################################################
@@ -49,13 +50,14 @@ cryptography==42.0.8
 └── cffi [required: >=1.12, installed: 1.16.0]
     └── pycparser [required: Any, installed: 2.22]
 oms-mqclient
-└── wipac-dev-tools [required: Any, installed: 1.10.6]
-    ├── requests [required: Any, installed: 2.32.3]
-    │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
-    │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.7]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
-    └── typing_extensions [required: Any, installed: 4.12.2]
+├── wipac-dev-tools [required: Any, installed: 1.10.6]
+│   ├── requests [required: Any, installed: 2.32.3]
+│   │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
+│   │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
+│   │   ├── idna [required: >=2.5,<4, installed: 3.7]
+│   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
+│   └── typing_extensions [required: Any, installed: 4.12.2]
+└── zstd [required: Any, installed: 1.5.5.1]
 pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
 └── pip [required: >=23.1.2, installed: 24.0]

--- a/dependencies-integration.log
+++ b/dependencies-integration.log
@@ -39,7 +39,7 @@ typing_extensions==4.12.2
 Unidecode==1.3.8
 urllib3==2.2.2
 wipac-dev-tools==1.10.6
-wipac-keycloak-rest-services==1.4.101
+wipac-keycloak-rest-services==1.4.102
 wipac-rest-tools==1.7.5
 yarl==1.9.4
 ########################################################################
@@ -67,7 +67,7 @@ pytest-xdist==3.6.1
     └── pluggy [required: >=1.5,<2.0, installed: 1.5.0]
 setuptools==65.5.1
 wheel==0.43.0
-wipac-keycloak-rest-services==1.4.101
+wipac-keycloak-rest-services==1.4.102
 ├── aio-pika [required: Any, installed: 9.4.1]
 │   ├── aiormq [required: >=6.8.0,<6.9.0, installed: 6.8.0]
 │   │   ├── pamqp [required: ==3.3.0, installed: 3.3.0]

--- a/dependencies-integration.log
+++ b/dependencies-integration.log
@@ -39,7 +39,7 @@ typing_extensions==4.12.2
 Unidecode==1.3.8
 urllib3==2.2.2
 wipac-dev-tools==1.10.6
-wipac-keycloak-rest-services==1.4.99
+wipac-keycloak-rest-services==1.4.101
 wipac-rest-tools==1.7.5
 yarl==1.9.4
 ########################################################################
@@ -56,7 +56,7 @@ oms-mqclient
     │   ├── idna [required: >=2.5,<4, installed: 3.7]
     │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
     └── typing_extensions [required: Any, installed: 4.12.2]
-pipdeptree==2.22.0
+pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
 └── pip [required: >=23.1.2, installed: 24.0]
 pytest-xdist==3.6.1
@@ -67,7 +67,7 @@ pytest-xdist==3.6.1
     └── pluggy [required: >=1.5,<2.0, installed: 1.5.0]
 setuptools==65.5.1
 wheel==0.43.0
-wipac-keycloak-rest-services==1.4.99
+wipac-keycloak-rest-services==1.4.101
 ├── aio-pika [required: Any, installed: 9.4.1]
 │   ├── aiormq [required: >=6.8.0,<6.9.0, installed: 6.8.0]
 │   │   ├── pamqp [required: ==3.3.0, installed: 3.3.0]

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -73,6 +73,7 @@ wipac-telemetry==0.3.0
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.19.2
+zstd==1.5.5.1
 ########################################################################
 #  pipdeptree
 ########################################################################
@@ -87,13 +88,14 @@ mypy==1.10.0
 nats-py==2.7.2
 nkeys==0.2.0
 oms-mqclient
-└── wipac-dev-tools [required: Any, installed: 1.10.6]
-    ├── requests [required: Any, installed: 2.32.3]
-    │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
-    │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.7]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
-    └── typing_extensions [required: Any, installed: 4.12.2]
+├── wipac-dev-tools [required: Any, installed: 1.10.6]
+│   ├── requests [required: Any, installed: 2.32.3]
+│   │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
+│   │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
+│   │   ├── idna [required: >=2.5,<4, installed: 3.7]
+│   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
+│   └── typing_extensions [required: Any, installed: 4.12.2]
+└── zstd [required: Any, installed: 1.5.5.1]
 pika==1.3.2
 pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -67,7 +67,7 @@ typing_extensions==4.12.2
 Unidecode==1.3.8
 urllib3==2.2.2
 wipac-dev-tools==1.10.6
-wipac-keycloak-rest-services==1.4.101
+wipac-keycloak-rest-services==1.4.102
 wipac-rest-tools==1.7.5
 wipac-telemetry==0.3.0
 wrapt==1.16.0
@@ -118,7 +118,7 @@ pytest-xdist==3.6.1
     └── pluggy [required: >=1.5,<2.0, installed: 1.5.0]
 setuptools==65.5.1
 wheel==0.43.0
-wipac-keycloak-rest-services==1.4.101
+wipac-keycloak-rest-services==1.4.102
 ├── aio-pika [required: Any, installed: 9.4.1]
 │   ├── aiormq [required: >=6.8.0,<6.9.0, installed: 6.8.0]
 │   │   ├── pamqp [required: ==3.3.0, installed: 3.3.0]

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -67,7 +67,7 @@ typing_extensions==4.12.2
 Unidecode==1.3.8
 urllib3==2.2.2
 wipac-dev-tools==1.10.6
-wipac-keycloak-rest-services==1.4.99
+wipac-keycloak-rest-services==1.4.101
 wipac-rest-tools==1.7.5
 wipac-telemetry==0.3.0
 wrapt==1.16.0
@@ -95,7 +95,7 @@ oms-mqclient
     │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
     └── typing_extensions [required: Any, installed: 4.12.2]
 pika==1.3.2
-pipdeptree==2.22.0
+pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
 └── pip [required: >=23.1.2, installed: 24.0]
 pulsar-client==3.5.0
@@ -118,7 +118,7 @@ pytest-xdist==3.6.1
     └── pluggy [required: >=1.5,<2.0, installed: 1.5.0]
 setuptools==65.5.1
 wheel==0.43.0
-wipac-keycloak-rest-services==1.4.99
+wipac-keycloak-rest-services==1.4.101
 ├── aio-pika [required: Any, installed: 9.4.1]
 │   ├── aiormq [required: >=6.8.0,<6.9.0, installed: 6.8.0]
 │   │   ├── pamqp [required: ==3.3.0, installed: 3.3.0]

--- a/dependencies-nats.log
+++ b/dependencies-nats.log
@@ -15,19 +15,21 @@ requests==2.32.3
 typing_extensions==4.12.2
 urllib3==2.2.2
 wipac-dev-tools==1.10.6
+zstd==1.5.5.1
 ########################################################################
 #  pipdeptree
 ########################################################################
 nats-py==2.7.2
 nkeys==0.2.0
 oms-mqclient
-└── wipac-dev-tools [required: Any, installed: 1.10.6]
-    ├── requests [required: Any, installed: 2.32.3]
-    │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
-    │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.7]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
-    └── typing_extensions [required: Any, installed: 4.12.2]
+├── wipac-dev-tools [required: Any, installed: 1.10.6]
+│   ├── requests [required: Any, installed: 2.32.3]
+│   │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
+│   │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
+│   │   ├── idna [required: >=2.5,<4, installed: 3.7]
+│   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
+│   └── typing_extensions [required: Any, installed: 4.12.2]
+└── zstd [required: Any, installed: 1.5.5.1]
 pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
 └── pip [required: >=23.1.2, installed: 24.0]

--- a/dependencies-nats.log
+++ b/dependencies-nats.log
@@ -28,7 +28,7 @@ oms-mqclient
     │   ├── idna [required: >=2.5,<4, installed: 3.7]
     │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
     └── typing_extensions [required: Any, installed: 4.12.2]
-pipdeptree==2.22.0
+pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
 └── pip [required: >=23.1.2, installed: 24.0]
 setuptools==65.5.1

--- a/dependencies-pulsar.log
+++ b/dependencies-pulsar.log
@@ -25,7 +25,7 @@ oms-mqclient
     │   ├── idna [required: >=2.5,<4, installed: 3.7]
     │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
     └── typing_extensions [required: Any, installed: 4.12.2]
-pipdeptree==2.22.0
+pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
 └── pip [required: >=23.1.2, installed: 24.0]
 pulsar-client==3.5.0

--- a/dependencies-pulsar.log
+++ b/dependencies-pulsar.log
@@ -14,17 +14,19 @@ requests==2.32.3
 typing_extensions==4.12.2
 urllib3==2.2.2
 wipac-dev-tools==1.10.6
+zstd==1.5.5.1
 ########################################################################
 #  pipdeptree
 ########################################################################
 oms-mqclient
-└── wipac-dev-tools [required: Any, installed: 1.10.6]
-    ├── requests [required: Any, installed: 2.32.3]
-    │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
-    │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.7]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
-    └── typing_extensions [required: Any, installed: 4.12.2]
+├── wipac-dev-tools [required: Any, installed: 1.10.6]
+│   ├── requests [required: Any, installed: 2.32.3]
+│   │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
+│   │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
+│   │   ├── idna [required: >=2.5,<4, installed: 3.7]
+│   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
+│   └── typing_extensions [required: Any, installed: 4.12.2]
+└── zstd [required: Any, installed: 1.5.5.1]
 pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
 └── pip [required: >=23.1.2, installed: 24.0]

--- a/dependencies-rabbitmq.log
+++ b/dependencies-rabbitmq.log
@@ -26,7 +26,7 @@ oms-mqclient
     │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
     └── typing_extensions [required: Any, installed: 4.12.2]
 pika==1.3.2
-pipdeptree==2.22.0
+pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
 └── pip [required: >=23.1.2, installed: 24.0]
 setuptools==65.5.1

--- a/dependencies-rabbitmq.log
+++ b/dependencies-rabbitmq.log
@@ -14,17 +14,19 @@ requests==2.32.3
 typing_extensions==4.12.2
 urllib3==2.2.2
 wipac-dev-tools==1.10.6
+zstd==1.5.5.1
 ########################################################################
 #  pipdeptree
 ########################################################################
 oms-mqclient
-└── wipac-dev-tools [required: Any, installed: 1.10.6]
-    ├── requests [required: Any, installed: 2.32.3]
-    │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
-    │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.7]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
-    └── typing_extensions [required: Any, installed: 4.12.2]
+├── wipac-dev-tools [required: Any, installed: 1.10.6]
+│   ├── requests [required: Any, installed: 2.32.3]
+│   │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
+│   │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
+│   │   ├── idna [required: >=2.5,<4, installed: 3.7]
+│   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
+│   └── typing_extensions [required: Any, installed: 4.12.2]
+└── zstd [required: Any, installed: 1.5.5.1]
 pika==1.3.2
 pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]

--- a/dependencies-telemetry.log
+++ b/dependencies-telemetry.log
@@ -34,17 +34,19 @@ wipac-dev-tools==1.10.6
 wipac-telemetry==0.3.0
 wrapt==1.16.0
 zipp==3.19.2
+zstd==1.5.5.1
 ########################################################################
 #  pipdeptree
 ########################################################################
 oms-mqclient
-└── wipac-dev-tools [required: Any, installed: 1.10.6]
-    ├── requests [required: Any, installed: 2.32.3]
-    │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
-    │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.7]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
-    └── typing_extensions [required: Any, installed: 4.12.2]
+├── wipac-dev-tools [required: Any, installed: 1.10.6]
+│   ├── requests [required: Any, installed: 2.32.3]
+│   │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
+│   │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
+│   │   ├── idna [required: >=2.5,<4, installed: 3.7]
+│   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
+│   └── typing_extensions [required: Any, installed: 4.12.2]
+└── zstd [required: Any, installed: 1.5.5.1]
 pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
 └── pip [required: >=23.1.2, installed: 24.0]

--- a/dependencies-telemetry.log
+++ b/dependencies-telemetry.log
@@ -45,7 +45,7 @@ oms-mqclient
     │   ├── idna [required: >=2.5,<4, installed: 3.7]
     │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
     └── typing_extensions [required: Any, installed: 4.12.2]
-pipdeptree==2.22.0
+pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
 └── pip [required: >=23.1.2, installed: 24.0]
 setuptools==65.5.1

--- a/dependencies.log
+++ b/dependencies.log
@@ -13,17 +13,19 @@ requests==2.32.3
 typing_extensions==4.12.2
 urllib3==2.2.2
 wipac-dev-tools==1.10.6
+zstd==1.5.5.1
 ########################################################################
 #  pipdeptree
 ########################################################################
 oms-mqclient
-└── wipac-dev-tools [required: Any, installed: 1.10.6]
-    ├── requests [required: Any, installed: 2.32.3]
-    │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
-    │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
-    │   ├── idna [required: >=2.5,<4, installed: 3.7]
-    │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
-    └── typing_extensions [required: Any, installed: 4.12.2]
+├── wipac-dev-tools [required: Any, installed: 1.10.6]
+│   ├── requests [required: Any, installed: 2.32.3]
+│   │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
+│   │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
+│   │   ├── idna [required: >=2.5,<4, installed: 3.7]
+│   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
+│   └── typing_extensions [required: Any, installed: 4.12.2]
+└── zstd [required: Any, installed: 1.5.5.1]
 pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
 └── pip [required: >=23.1.2, installed: 24.0]

--- a/dependencies.log
+++ b/dependencies.log
@@ -24,7 +24,7 @@ oms-mqclient
     │   ├── idna [required: >=2.5,<4, installed: 3.7]
     │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
     └── typing_extensions [required: Any, installed: 4.12.2]
-pipdeptree==2.22.0
+pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
 └── pip [required: >=23.1.2, installed: 24.0]
 setuptools==65.5.1

--- a/mqclient/broker_client_interface.py
+++ b/mqclient/broker_client_interface.py
@@ -49,10 +49,10 @@ class Message:
             raise TypeError(
                 f"Message.msg_id must be type int|str|bytes (not '{type(msg_id)}')."
             )
-        # if not isinstance(payload, bytes): TODO - keep/fix/remove
-        #     raise TypeError(
-        #         f"Message.data must be type 'bytes' (not '{type(payload)}')."
-        #     )
+        if not isinstance(payload, bytes):
+            raise TypeError(
+                f"Message.data must be type 'bytes' (not '{type(payload)}')."
+            )
         self.msg_id = msg_id
         self.payload = payload
         self._ack_status: Message.AckStatus = Message.AckStatus.NONE

--- a/mqclient/broker_client_interface.py
+++ b/mqclient/broker_client_interface.py
@@ -5,7 +5,7 @@ import uuid
 from enum import Enum, auto
 from typing import Any, AsyncGenerator, Dict, Optional, Union
 
-import zstd
+import zstd  # type: ignore[import-not-found]  # false negative by mypy
 
 from .config import MIN_PREFETCH
 

--- a/mqclient/broker_client_interface.py
+++ b/mqclient/broker_client_interface.py
@@ -94,7 +94,7 @@ class Message:
 
     @staticmethod
     def serialize(data: Any, headers: Optional[Dict[str, Any]] = None) -> bytes:
-        """Return serialized representation of message payload as a json str.
+        """Return serialized representation of message payload as a json bytes str.
 
         Optionally include `headers` dict for internal information.
         """

--- a/mqclient/broker_client_interface.py
+++ b/mqclient/broker_client_interface.py
@@ -83,14 +83,14 @@ class Message:
     def data(self) -> Any:
         """Read and return an object from the `data` field."""
         if not self._data:
-            self._data = pickle.loads(self.payload)["data"]
+            self._data = json.loads(self.payload)["data"]
         return self._data
 
     @property
     def headers(self) -> Any:
         """Read and return dict from the `headers` field."""
         if not self._headers:
-            self._headers = pickle.loads(self.payload)["headers"]
+            self._headers = json.loads(self.payload)["headers"]
         return self._headers
 
     @staticmethod

--- a/mqclient/broker_client_interface.py
+++ b/mqclient/broker_client_interface.py
@@ -109,7 +109,8 @@ class Message:
 
         return zstd.compress(
             json.dumps({"headers": headers, "data": data}).encode("utf-8"),
-            __threads=1,
+            3,  # level (3 is default)
+            1,  # num of threads (auto is default)
         )
 
 

--- a/mqclient/broker_client_interface.py
+++ b/mqclient/broker_client_interface.py
@@ -90,7 +90,7 @@ class Message:
         return self._deserialize()["headers"]
 
     def _deserialize(self) -> Dict[str, Any]:
-        if self._deserialized_payload:
+        if not self._deserialized_payload:
             self._deserialized_payload = json.loads(zstd.decompress(self.payload))
         return self._deserialized_payload
 

--- a/mqclient/broker_client_interface.py
+++ b/mqclient/broker_client_interface.py
@@ -108,7 +108,8 @@ class Message:
             headers = {}
 
         return zstd.compress(
-            json.dumps({"headers": headers, "data": data}).encode("utf-8")
+            json.dumps({"headers": headers, "data": data}).encode("utf-8"),
+            __threads=1,
         )
 
 

--- a/mqclient/broker_client_interface.py
+++ b/mqclient/broker_client_interface.py
@@ -1,7 +1,6 @@
 """Define an interface that broker_clients will adhere to."""
 
 import json
-import pickle
 import uuid
 from enum import Enum, auto
 from typing import Any, AsyncGenerator, Dict, Optional, Union
@@ -94,7 +93,7 @@ class Message:
         return self._headers
 
     @staticmethod
-    def serialize(data: Any, headers: Optional[Dict[str, Any]] = None) -> str:
+    def serialize(data: Any, headers: Optional[Dict[str, Any]] = None) -> bytes:
         """Return serialized representation of message payload as a json str.
 
         Optionally include `headers` dict for internal information.
@@ -102,20 +101,7 @@ class Message:
         if not headers:
             headers = {}
 
-        encoded_data: Union[str, bytes]
-        try:
-            encoded_data = json.dumps(data)
-            headers["Data-Type"] = "json"
-        except TypeError:
-            encoded_data = pickle.dumps(data, protocol=5)  # 5 is only avail for py 3.8+
-            headers["Data-Type"] = "pickle"
-
-        return json.dumps(
-            {
-                "headers": headers,
-                "data": encoded_data,
-            }
-        )
+        return json.dumps({"headers": headers, "data": data}).encode("utf-8")
 
 
 # -----------------------------

--- a/mqclient/broker_client_interface.py
+++ b/mqclient/broker_client_interface.py
@@ -49,10 +49,10 @@ class Message:
             raise TypeError(
                 f"Message.msg_id must be type int|str|bytes (not '{type(msg_id)}')."
             )
-        if not isinstance(payload, bytes):
-            raise TypeError(
-                f"Message.data must be type 'bytes' (not '{type(payload)}')."
-            )
+        # if not isinstance(payload, bytes): TODO - keep/fix/remove
+        #     raise TypeError(
+        #         f"Message.data must be type 'bytes' (not '{type(payload)}')."
+        #     )
         self.msg_id = msg_id
         self.payload = payload
         self._ack_status: Message.AckStatus = Message.AckStatus.NONE

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -429,7 +429,10 @@ class QueuePubResource:
 
     @wtt.spanned(kind=wtt.SpanKind.PRODUCER)
     async def send(self, data: Any) -> None:
-        """Send a message."""
+        """Send a message.
+
+        Data must be JSON serializable.
+        """
         msg_bytes = Message.serialize(data, headers=wtt.inject_links_carrier())
         LOGGER.info(f"Sending Message: {sys.getsizeof(msg_bytes)} bytes")
         await self.pub.send_message(

--- a/resources/message_compression_benchmarking.py
+++ b/resources/message_compression_benchmarking.py
@@ -134,6 +134,14 @@ def main():
         else:
             compress_decompress(gzip, data)
 
+    elif args.algo == "lz4":
+        import lz4.frame  # type: ignore
+
+        if args.only_size:
+            compare_size(lz4.frame, data)
+        else:
+            compress_decompress(lz4.frame, data)
+
     else:
         raise Exception("invalid compression algorithm specified")
 

--- a/resources/message_compression_benchmarking.py
+++ b/resources/message_compression_benchmarking.py
@@ -119,7 +119,11 @@ def main():
     elif args.algo == "zstd":
         import zstd  # type: ignore
 
-        zstd_compress_1thread = lambda x: zstd.compress(x, -3, 1)  # -3 is default
+        zstd_compress_1thread = lambda x: zstd.compress(  # noqa: E731
+            x,
+            3,  # level (3 is default)
+            1,  # num of threads (auto is default)
+        )
         if args.only_size:
             compare_size(args.algo, zstd_compress_1thread, data)
         else:

--- a/resources/message_compression_benchmarking.py
+++ b/resources/message_compression_benchmarking.py
@@ -17,7 +17,7 @@ def compare_size(algo_pkg, data):
         import base64
 
         data = base64.b64encode(data).decode("utf-8")
-        print(f"\nthe following use base64 first...\n")
+        print("\nthe following use base64 first...\n")
 
     compressed_size = len(algo_pkg.compress(json.dumps(data).encode()))
     print(

--- a/resources/message_compression_benchmarking.py
+++ b/resources/message_compression_benchmarking.py
@@ -1,0 +1,142 @@
+"""Script for benchmarking different message compression options."""
+
+import argparse
+import json
+
+TITLE_SPACING = 20
+SIZE_SPACING = 8
+
+
+def compare_size(algo_pkg, data):
+    """Compare the size of the data in various compression methods."""
+
+    was_bytes = False
+    if isinstance(data, bytes):
+        was_bytes = True
+        print(f"{'raw bytes':{TITLE_SPACING}} {len(data):{SIZE_SPACING}}")
+        import base64
+
+        data = base64.b64encode(data).decode("utf-8")
+        print(f"\nthe following use base64 first...\n")
+
+    compressed_size = len(algo_pkg.compress(json.dumps(data).encode()))
+    print(
+        f"{f'json+encode+{algo_pkg.__name__}':{TITLE_SPACING}} {compressed_size:{SIZE_SPACING}}"
+    )
+
+    json_encoded_size = len(json.dumps(data).encode())
+    print(
+        f"{'only json+encode':{TITLE_SPACING}} {json_encoded_size:{SIZE_SPACING}} (comp. ratio: {compressed_size / json_encoded_size:.3f})"
+    )
+
+    import pickle
+
+    if not was_bytes:
+        pickle_size = len(pickle.dumps(data))
+        print(
+            f"{'only pickled':{TITLE_SPACING}} {pickle_size:{SIZE_SPACING}} (comp. ratio: {compressed_size / pickle_size:.3f})"
+        )
+
+
+def compress_decompress(algo_pkg, data):
+    if isinstance(data, bytes):
+        import base64
+
+        data = base64.b64encode(data).decode("utf-8")
+    comp_data = algo_pkg.compress(json.dumps(data).encode())
+    out_data = json.loads(algo_pkg.decompress(comp_data))
+    # just in case there's a typo, check the data
+    assert out_data == data
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--algo", required=True)
+    parser.add_argument("--data", required=True)
+    parser.add_argument("--only-size", action="store_true")
+    args = parser.parse_args()
+
+    # get data
+
+    if args.data == "large_dict":
+        data = {
+            chr(i): [{chr(k % (i + 1)): k} for k in range(1000)] for i in range(100)
+        }
+    elif args.data == "medium_string":
+        data = "\n".join(
+            [
+                "The quick brown fox jumps over the lazy dog.",
+                "She sells sea shells by the sea shore.",
+                "How much wood would a woodchuck chuck if a woodchuck could chuck wood?",
+                "Peter Piper picked a peck of pickled peppers.",
+                "A journey of a thousand miles begins with a single step.",
+                "To be or not to be, that is the question.",
+                "All that glitters is not gold.",
+                "A picture is worth a thousand words.",
+                "Actions speak louder than words.",
+                "Better late than never.",
+                "Birds of a feather flock together.",
+                "Fortune favors the bold.",
+                "A watched pot never boils.",
+                "Beauty is in the eye of the beholder.",
+                "Beggars can't be choosers.",
+                "Cleanliness is next to godliness.",
+                "Discretion is the better part of valor.",
+                "Every cloud has a silver lining.",
+                "Good things come to those who wait.",
+                "Haste makes waste.",
+                "If it ain't broke, don't fix it.",
+                "Laughter is the best medicine.",
+                "Necessity is the mother of invention.",
+                "No man is an island.",
+                "Practice makes perfect.",
+                "Rome wasn't built in a day.",
+                "The early bird catches the worm.",
+                "The pen is mightier than the sword.",
+            ]
+        )
+    elif args.data == "skyscan_i3_frame_pkl":
+        data = b"\x80\x04\x95\x96\x02\x00\x00\x00\x00\x00\x00\x8c\x10icecube._icetray\x94\x8c\x07I3Frame\x94\x93\x94)R\x94}\x94Bh\x02\x00\x00[i3]\x06\x00\x00\x00\x00\x00P\x05\x00\x00\x00\r\x00\x00\x00I3EventHeader\r\x00\x00\x00I3EventHeader\x86\x00\x00\x00\x00\x01\x02\x00\r\x00\x00\x00I3EventHeader\x01\x03\x00\x00\x00\x00\x01\x00\x01\x00\x00\x00>\x16\x02\x00\x00\x00\x00\x00\x94\x88t\x00\x14\x00\x00\x00\x08\x00\x00\x00#\x00\x00\x00SCAN_nside0001_pixel0008_posvar0000\x01\x00\x02\x00\x00\x00\x03\x00\x00\x00\xe6\x07\x00\x00\xc1\x9d\xde^\xe8,\x18\x02\x04\x00\x00\x00\x05\x00\x00\x00\xe6\x07\x00\x00o\xa0\xe1^\xe8,\x18\x02\x15\x00\x00\x00MillipedeSeedParticle\n\x00\x00\x00I3Particle\x96\x00\x00\x00\x00\x01\x02\x00\n\x00\x00\x00I3Particle\x01\x05\x00\x00\x00\x00\x01\x00\x01\x00\x00\x00\x14\x00\x00\x00N\t\xb7q\xd0\xd0\x14U\x00\x00\x00\x00(\x00\x00\x00\x00\x00\x00\x00\x01\x00\x02\x00\x00\x00\x03\x00\x00\x00\xaeG\xe1z\x14\xdec@H\xe1z\x14\xae\x93u\xc0\n\xd7\xa3p=\x86\x7f\xc0\x01\x00\x04\x00\x00\x00\x05\x00\x00\x00\xa8aF\x06fj\x02@\x88\xe5:\xd1\xc7\x07\x0c@\x00\x00\x00\x00jr&A\x00\x00\x00\x00\x00\x00\xf8\x7f\x00\x00\x00\x00\x00\x00\xf8\x7f\x14\xa3\xac\xb4\xcc/\xd3?\x00\x00\x00\x00\x11\x00\x00\x00SCAN_HealpixNSide\x10\x00\x00\x00I3PODHolder<int>\x1d\x00\x00\x00\x00\x01\x02\x00\x05\x00\x00\x00I3Int\x01\x00\x00\x00\x00\x00\x01\x00\x01\x00\x00\x00\x01\x00\x00\x00\x11\x00\x00\x00SCAN_HealpixPixel\x10\x00\x00\x00I3PODHolder<int>\x1d\x00\x00\x00\x00\x01\x02\x00\x05\x00\x00\x00I3Int\x01\x00\x00\x00\x00\x00\x01\x00\x01\x00\x00\x00\x08\x00\x00\x00\x1b\x00\x00\x00SCAN_PositionVariationIndex\x10\x00\x00\x00I3PODHolder<int>\x1d\x00\x00\x00\x00\x01\x02\x00\x05\x00\x00\x00I3Int\x01\x00\x00\x00\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x00\x00\x1aU\x07\xa1\x94\x86\x94b."
+    else:
+        raise ValueError("invalid --data value")
+
+    # go!
+
+    if args.algo == "bz2":
+        import bz2
+
+        if args.only_size:
+            compare_size(bz2, data)
+        else:
+            compress_decompress(bz2, data)
+
+    elif args.algo == "lzma":
+        import lzma
+
+        if args.only_size:
+            compare_size(lzma, data)
+        else:
+            compress_decompress(lzma, data)
+
+    elif args.algo == "zstd":
+        import zstd  # type: ignore
+
+        if args.only_size:
+            compare_size(zstd, data)
+        else:
+            compress_decompress(zstd, data)
+
+    elif args.algo == "gzip":
+        import gzip
+
+        if args.only_size:
+            compare_size(gzip, data)
+        else:
+            compress_decompress(gzip, data)
+
+    else:
+        raise Exception("invalid compression algorithm specified")
+
+
+if __name__ == "__main__":
+    main()

--- a/resources/message_compression_benchmarking.py
+++ b/resources/message_compression_benchmarking.py
@@ -3,7 +3,7 @@
 import argparse
 import json
 
-TITLE_SPACING = 20
+TITLE_SPACING = 21
 SIZE_SPACING = 8
 
 

--- a/resources/message_compression_benchmarking.sh
+++ b/resources/message_compression_benchmarking.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+if [ -z $1 ]; then
+    echo "MISSING ARG: message_compression_benchmarking.sh N_ITERATIONS"
+    exit 1
+fi
+N_ITERATIONS=$1
+
+all_algos='bz2 lzma zstd gzip'
+all_data='large_dict medium_string skyscan_i3_frame_pkl'
+
+for algo in $all_algos; do
+	echo
+	echo "=============================================================="
+	echo "$algo:"
+	for data in $all_data; do
+		echo
+		echo "--------------------------------------"
+		echo "data=$data"
+		echo
+		python3 message_compression_benchmarking.py --algo $algo --data $data --only-size
+		echo
+		echo "iterations=$N_ITERATIONS (compress + decompress)"
+		time for i in $(seq 1 $N_ITERATIONS); do python3 message_compression_benchmarking.py --algo $algo --data $data; done
+	done
+done

--- a/resources/message_compression_benchmarking.sh
+++ b/resources/message_compression_benchmarking.sh
@@ -7,7 +7,7 @@ if [ -z $1 ]; then
 fi
 N_ITERATIONS=$1
 
-all_algos='bz2 lzma zstd gzip'
+all_algos='bz2 lzma zstd gzip lz4'
 all_data='large_dict medium_string skyscan_i3_frame_pkl'
 
 for algo in $all_algos; do

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ python_requires = >=3.8, <3.13
 packages = find:
 install_requires =
 	wipac-dev-tools
+	zstd
 
 [options.extras_require]
 all =
@@ -116,18 +117,18 @@ parallel = True
 [coverage:report]
 # regexes for lines to exclude from consideration
 exclude_lines =
-	# Have to re-enable the standard pragma
+# Have to re-enable the standard pragma
 	pragma: no cover
 
-	# Don't complain about missing debug-only code:
+# Don't complain about missing debug-only code:
 	def __repr__
 	if self\.debug
 
-	# Don't complain if tests don't hit defensive assertion code:
+# Don't complain if tests don't hit defensive assertion code:
 	raise AssertionError
 	raise NotImplementedError
 
-	# Don't complain if non-runnable code isn't run:
+# Don't complain if non-runnable code isn't run:
 	if 0:
 	if __name__ == .__main__.:
 omit = *__init__*
@@ -141,4 +142,3 @@ ignore = E226,E261,E302,E305,E501,W503,W504
 
 [tool:pytest]
 testpaths = mqclient tests
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ python_requires = >=3.8, <3.13
 packages = find:
 install_requires =
 	wipac-dev-tools
-	zstd
+zstd
 
 [options.extras_require]
 all =
@@ -109,33 +109,6 @@ exclude =
 	resources
 	example
 	examples
-
-[coverage:run]
-branch = True
-parallel = True
-
-[coverage:report]
-# regexes for lines to exclude from consideration
-exclude_lines =
-# Have to re-enable the standard pragma
-	pragma: no cover
-
-# Don't complain about missing debug-only code:
-	def __repr__
-	if self\.debug
-
-# Don't complain if tests don't hit defensive assertion code:
-	raise AssertionError
-	raise NotImplementedError
-
-# Don't complain if non-runnable code isn't run:
-	if 0:
-	if __name__ == .__main__.:
-omit = *__init__*
-ignore_errors = True
-
-[coverage:html]
-directory = htmlcov
 
 [flake8]
 ignore = E226,E261,E302,E305,E501,W503,W504

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ python_requires = >=3.8, <3.13
 packages = find:
 install_requires =
 	wipac-dev-tools
-zstd
+	zstd
 
 [options.extras_require]
 all =

--- a/setup.cfg
+++ b/setup.cfg
@@ -115,3 +115,4 @@ ignore = E226,E261,E302,E305,E501,W503,W504
 
 [tool:pytest]
 testpaths = mqclient tests
+

--- a/tests/abstract_broker_client_tests/integrate_broker_client_interface.py
+++ b/tests/abstract_broker_client_tests/integrate_broker_client_interface.py
@@ -33,6 +33,9 @@ class MyComplexDataForTest01:
     def __init__(self, inner_data):
         self.inner_data = inner_data
 
+    def __eq__(self, other) -> bool:
+        return self.inner_data == other.inner_data
+
 
 class PubSubBrokerClientInterface:
     """Integration test suite for broker_client_interface objects.
@@ -158,6 +161,7 @@ class PubSubBrokerClientInterface:
             assert recv_msg
             # str -> bytes -> obj
             decoded_msg = pickle.loads(base64.b64decode(recv_msg.data))
+            assert isinstance(pickable_data_list[i], type(decoded_msg))
             assert pickable_data_list[i] == decoded_msg
 
             await sub.ack_message(

--- a/tests/abstract_broker_client_tests/integrate_broker_client_interface.py
+++ b/tests/abstract_broker_client_tests/integrate_broker_client_interface.py
@@ -25,6 +25,13 @@ def _log_recv_message(recv_msg: Optional[Message]) -> None:
     _log_recv(f"{recv_msg} -> {recv_data}")
 
 
+class MyComplexDataForTest01:
+    """Used in test 01."""
+
+    def __init__(self, inner_data):
+        self.inner_data = inner_data
+
+
 class PubSubBrokerClientInterface:
     """Integration test suite for broker_client_interface objects.
 
@@ -95,11 +102,7 @@ class PubSubBrokerClientInterface:
             "localhost", queue_name, 1, auth_token
         )
 
-        class MyComplexData:
-            def __init__(self, inner_data):
-                self.inner_data = inner_data
-
-        pickable_data_list = [MyComplexData(d) for d in DATA_LIST]
+        pickable_data_list = [MyComplexDataForTest01(d) for d in DATA_LIST]
 
         # sanity check
         with pytest.raises(TypeError):


### PR DESCRIPTION
The user will be required to serialize (and deserialize) more complex object types (ie, use `pickle`, `base64`, etc.), or implement `toJSON()` method(s) for their objects' class(es).

Previously, `pickle` was used for all serialization, which has runtime implications upon deserialization. Depickling complex objects requires third-party packages, which opens up many tricky scenarios that the user should be responsible for remedying (availability, versioning, etc.).

Moreover, this update is required for https://github.com/Observation-Management-Service/ewms-pilot/issues/73